### PR TITLE
[Feat/#9] 일정 투표 생성,조회,삭제

### DIFF
--- a/src/docs/asciidoc/api/vote/vote.adoc
+++ b/src/docs/asciidoc/api/vote/vote.adoc
@@ -19,3 +19,37 @@ include::{snippets}/vote-stadium-get/http-request.adoc[]
 ==== HTTP Response
 include::{snippets}/vote-stadium-get/http-response.adoc[]
 include::{snippets}/vote-stadium-get/response-fields.adoc[]
+
+[[vote-date-create]]
+=== Vote Date 생성
+
+==== HTTP Request
+include::{snippets}/vote-date-create/http-request.adoc[]
+include::{snippets}/vote-date-create/request-fields.adoc[]
+include::{snippets}/vote-date-create/path-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/vote-date-create/http-response.adoc[]
+include::{snippets}/vote-date-create/response-fields.adoc[]
+
+[[vote-date-get]]
+=== Vote Date 단건 조회
+
+==== HTTP Request
+include::{snippets}/vote-date-get/http-request.adoc[]
+include::{snippets}/vote-date-get/path-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/vote-date-get/http-response.adoc[]
+include::{snippets}/vote-date-get/response-fields.adoc[]
+
+[[vote-delete]]
+=== Vote 삭제
+
+==== HTTP Request
+include::{snippets}/vote-delete/http-request.adoc[]
+include::{snippets}/vote-delete/path-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/vote-delete/http-response.adoc[]
+include::{snippets}/vote-delete/response-fields.adoc[]

--- a/src/main/java/team4/footwithme/config/SecurityConfig.java
+++ b/src/main/java/team4/footwithme/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -26,23 +27,31 @@ public class SecurityConfig {
 
 
     @Bean
-    public BCryptPasswordEncoder passwordEncoder() { return new BCryptPasswordEncoder(); }
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 
     @Bean
-    public RestTemplate restTemplate() { return new RestTemplate(); }
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity
-                .httpBasic(AbstractHttpConfigurer::disable)
-                .csrf(AbstractHttpConfigurer::disable)
-                .sessionManagement((sessionManagement) -> sessionManagement
-                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .csrf(AbstractHttpConfigurer::disable)
+            .sessionManagement((sessionManagement) -> sessionManagement
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            )
+            .authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
+                .requestMatchers("/**").permitAll()
+            )
+            .headers((headerConfig)->
+                headerConfig.frameOptions((HeadersConfigurer.FrameOptionsConfig::sameOrigin)
                 )
-                .authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
-                        .requestMatchers("/**").permitAll()
-                )
-                .addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter.class);
+            )
+            .addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter.class);
 
         return httpSecurity.build();
     }

--- a/src/main/java/team4/footwithme/config/redis/EmbeddedRedisConfig.java
+++ b/src/main/java/team4/footwithme/config/redis/EmbeddedRedisConfig.java
@@ -7,6 +7,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import redis.embedded.RedisServer;
 
+import java.io.File;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+
 
 /**
  * 로컬 환경일경우 내장 레디스가 실행됩니다.
@@ -22,8 +26,12 @@ public class EmbeddedRedisConfig {
 
     @PostConstruct
     public void redisServer() {
-        redisServer = new RedisServer(redisPort);
-        redisServer.start();
+        if(isArmMac()) {
+            redisServer = new RedisServer(getRedisServerExecutable(), redisPort);
+        } else {
+            redisServer = new RedisServer(redisPort);
+            redisServer.start();
+        }
     }
 
     @PreDestroy
@@ -31,5 +39,17 @@ public class EmbeddedRedisConfig {
         if (redisServer != null) {
             redisServer.stop();
         }
+    }
+
+    private File getRedisServerExecutable(){
+        try {
+            return new File("src/main/resources/binary/redis/redis-server-6.2.5-mac-arm64");
+        } catch (Exception e) {
+            throw new NoSuchElementException("Redis Server Executable File Not Found");
+        }
+    }
+    private boolean isArmMac() {
+        return Objects.equals(System.getProperty("os.arch"), "aarch64")
+            && Objects.equals(System.getProperty("os.name"), "Mac OS X");
     }
 }

--- a/src/main/java/team4/footwithme/vote/api/VoteApi.java
+++ b/src/main/java/team4/footwithme/vote/api/VoteApi.java
@@ -33,4 +33,9 @@ public class VoteApi {
         return ApiResponse.created(voteService.createDateVote(request.toServiceRequest(), teamId, email));
     }
 
+    @GetMapping("/dates/{voteId}")
+    public ApiResponse<VoteResponse> getDateVote(@PathVariable Long voteId) {
+        return ApiResponse.ok(voteService.getDateVote(voteId));
+    }
+
 }

--- a/src/main/java/team4/footwithme/vote/api/VoteApi.java
+++ b/src/main/java/team4/footwithme/vote/api/VoteApi.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import team4.footwithme.global.api.ApiResponse;
+import team4.footwithme.vote.api.request.VoteDateCreateRequest;
 import team4.footwithme.vote.api.request.VoteStadiumCreateRequest;
 import team4.footwithme.vote.service.VoteService;
 import team4.footwithme.vote.service.response.VoteResponse;
@@ -24,6 +25,12 @@ public class VoteApi {
     @GetMapping("{voteId}")
     public ApiResponse<VoteResponse> getVote(@PathVariable Long voteId) {
         return ApiResponse.ok(voteService.getStadiumVote(voteId));
+    }
+
+    @PostMapping("/dates/{teamId}")
+    public ApiResponse<VoteResponse> createDateVote(@Valid @RequestBody VoteDateCreateRequest request, @PathVariable Long teamId) {
+        String email = "email@test.com";
+        return ApiResponse.created(voteService.createDateVote(request.toServiceRequest(), teamId, email));
     }
 
 }

--- a/src/main/java/team4/footwithme/vote/api/VoteApi.java
+++ b/src/main/java/team4/footwithme/vote/api/VoteApi.java
@@ -38,4 +38,9 @@ public class VoteApi {
         return ApiResponse.ok(voteService.getDateVote(voteId));
     }
 
+    @DeleteMapping("{voteId}")
+    public ApiResponse<Long> deleteVote(@PathVariable Long voteId) {
+        return ApiResponse.ok(voteService.deleteVote(voteId));
+    }
+
 }

--- a/src/main/java/team4/footwithme/vote/api/request/DateChoices.java
+++ b/src/main/java/team4/footwithme/vote/api/request/DateChoices.java
@@ -1,0 +1,8 @@
+package team4.footwithme.vote.api.request;
+
+import java.time.LocalDateTime;
+
+public record DateChoices (
+    LocalDateTime choice
+) {
+}

--- a/src/main/java/team4/footwithme/vote/api/request/VoteDateCreateRequest.java
+++ b/src/main/java/team4/footwithme/vote/api/request/VoteDateCreateRequest.java
@@ -1,0 +1,31 @@
+package team4.footwithme.vote.api.request;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import team4.footwithme.vote.api.request.annotation.Duplicate;
+import team4.footwithme.vote.service.request.VoteDateCreateServiceRequest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record VoteDateCreateRequest(
+    @NotBlank(message = "제목은 필수입니다.")
+    @Size(max = 50, message = "제목은 50자 이하여야 합니다.")
+    String title,
+    @Future(message = "투표 종료 시간은 현재 시간보다 미래의 시간으로 지정해야합니다.")
+    LocalDateTime endAt,
+    @Size(min = 1, message = "일정 선택은 필수입니다.")
+    List<DateChoices> choices
+) {
+
+    public VoteDateCreateServiceRequest toServiceRequest() {
+        return new VoteDateCreateServiceRequest(
+            title,
+            endAt,
+            choices.stream()
+                .map(DateChoices::choice)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/team4/footwithme/vote/domain/VoteItemDate.java
+++ b/src/main/java/team4/footwithme/vote/domain/VoteItemDate.java
@@ -14,14 +14,18 @@ import java.time.LocalDateTime;
 @Entity
 public class VoteItemDate extends VoteItem {
 
-    @NotNull
-    private LocalDateTime endAt;
-
+    private LocalDateTime time;
 
     @Builder
-    private VoteItemDate(Vote vote, LocalDateTime endAt) {
+    private VoteItemDate(Vote vote, LocalDateTime time) {
         super(vote);
-        this.endAt = endAt;
+        this.time = time;
     }
 
+    public static VoteItemDate create(Vote vote, LocalDateTime time) {
+        return VoteItemDate.builder()
+            .vote(vote)
+            .time(time)
+            .build();
+    }
 }

--- a/src/main/java/team4/footwithme/vote/repository/CustomChoiceRepositoryImpl.java
+++ b/src/main/java/team4/footwithme/vote/repository/CustomChoiceRepositoryImpl.java
@@ -15,9 +15,9 @@ public class CustomChoiceRepositoryImpl implements CustomChoiceRepository {
 
     @Override
     public Long countByVoteItemId(Long voteItemId) {
-        return queryFactory.select(choice)
+        return queryFactory.select(choice.count())
             .from(choice)
             .where(choice.voteItemId.eq(voteItemId))
-            .fetchCount();
+            .fetchOne();
     }
 }

--- a/src/main/java/team4/footwithme/vote/repository/VoteItemRepository.java
+++ b/src/main/java/team4/footwithme/vote/repository/VoteItemRepository.java
@@ -10,5 +10,5 @@ import java.util.List;
 @Repository
 public interface VoteItemRepository extends JpaRepository<VoteItem, Long> {
 
-    List<VoteItemLocate> findByVoteVoteId(long voteId);
+    List<VoteItem> findByVoteVoteId(Long voteId);
 }

--- a/src/main/java/team4/footwithme/vote/service/VoteService.java
+++ b/src/main/java/team4/footwithme/vote/service/VoteService.java
@@ -7,7 +7,9 @@ import team4.footwithme.vote.service.response.VoteResponse;
 public interface VoteService {
     VoteResponse createStadiumVote(VoteStadiumCreateServiceRequest request, Long teamId, String email);
 
-    VoteResponse getStadiumVote(long voteId);
+    VoteResponse getStadiumVote(Long voteId);
 
     VoteResponse createDateVote(VoteDateCreateServiceRequest request, Long teamId, String email);
+
+    VoteResponse getDateVote(Long voteId);
 }

--- a/src/main/java/team4/footwithme/vote/service/VoteService.java
+++ b/src/main/java/team4/footwithme/vote/service/VoteService.java
@@ -1,5 +1,6 @@
 package team4.footwithme.vote.service;
 
+import team4.footwithme.vote.service.request.VoteDateCreateServiceRequest;
 import team4.footwithme.vote.service.request.VoteStadiumCreateServiceRequest;
 import team4.footwithme.vote.service.response.VoteResponse;
 
@@ -7,4 +8,6 @@ public interface VoteService {
     VoteResponse createStadiumVote(VoteStadiumCreateServiceRequest request, Long teamId, String email);
 
     VoteResponse getStadiumVote(long voteId);
+
+    VoteResponse createDateVote(VoteDateCreateServiceRequest request, Long teamId, String email);
 }

--- a/src/main/java/team4/footwithme/vote/service/VoteService.java
+++ b/src/main/java/team4/footwithme/vote/service/VoteService.java
@@ -12,4 +12,6 @@ public interface VoteService {
     VoteResponse createDateVote(VoteDateCreateServiceRequest request, Long teamId, String email);
 
     VoteResponse getDateVote(Long voteId);
+
+    Long deleteVote(Long voteId);
 }

--- a/src/main/java/team4/footwithme/vote/service/VoteServiceImpl.java
+++ b/src/main/java/team4/footwithme/vote/service/VoteServiceImpl.java
@@ -160,4 +160,10 @@ public class VoteServiceImpl implements VoteService {
         return VoteItemResponse.of(voteItemId, content, count);
     }
 
+    @Transactional
+    @Override
+    public Long deleteVote(Long voteId) {
+        voteRepository.delete(getVote(voteId));
+        return voteId;
+    }
 }

--- a/src/main/java/team4/footwithme/vote/service/request/VoteDateCreateServiceRequest.java
+++ b/src/main/java/team4/footwithme/vote/service/request/VoteDateCreateServiceRequest.java
@@ -1,0 +1,12 @@
+package team4.footwithme.vote.service.request;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record VoteDateCreateServiceRequest(
+
+    String title,
+    LocalDateTime endAt,
+    List<LocalDateTime> choices
+) {
+}

--- a/src/test/java/team4/footwithme/docs/vote/VoteApiDocs.java
+++ b/src/test/java/team4/footwithme/docs/vote/VoteApiDocs.java
@@ -295,7 +295,7 @@ public class VoteApiDocs extends RestDocsSupport {
                 .contentType(MediaType.APPLICATION_JSON)
             )
             .andExpect(status().isOk())
-            .andDo(document("vote-date-create",
+            .andDo(document("vote-delete",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
                 pathParameters(

--- a/src/test/java/team4/footwithme/docs/vote/VoteApiDocs.java
+++ b/src/test/java/team4/footwithme/docs/vote/VoteApiDocs.java
@@ -1,14 +1,18 @@
 package team4.footwithme.docs.vote;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import team4.footwithme.docs.RestDocsSupport;
 import team4.footwithme.vote.api.VoteApi;
+import team4.footwithme.vote.api.request.DateChoices;
 import team4.footwithme.vote.api.request.StadiumChoices;
+import team4.footwithme.vote.api.request.VoteDateCreateRequest;
 import team4.footwithme.vote.api.request.VoteStadiumCreateRequest;
 import team4.footwithme.vote.service.VoteService;
+import team4.footwithme.vote.service.request.VoteDateCreateServiceRequest;
 import team4.footwithme.vote.service.request.VoteStadiumCreateServiceRequest;
 import team4.footwithme.vote.service.response.VoteItemResponse;
 import team4.footwithme.vote.service.response.VoteResponse;
@@ -151,6 +155,76 @@ public class VoteApiDocs extends RestDocsSupport {
                         .description("투표 선택지 투표 수")
                 )
             ));
+    }
+
+    @DisplayName("시간 투표를 등록하는 API")
+    @Test
+    void createDateVote() throws Exception {
+        LocalDateTime endAt = LocalDateTime.now().plusDays(5);
+        DateChoices choice1 = new DateChoices(LocalDateTime.now().plusHours(1));
+        DateChoices choice2 = new DateChoices(LocalDateTime.now().plusDays(1));
+        DateChoices choice3 = new DateChoices(LocalDateTime.now().plusDays(2));
+
+        VoteDateCreateRequest request = new VoteDateCreateRequest("연말 행사 투표", endAt, List.of(choice1, choice2, choice3));
+
+        given(voteService.createDateVote(any(VoteDateCreateServiceRequest.class),eq(1L),any(String.class)))
+            .willReturn(
+                new VoteResponse(
+                    1L,
+                    "연말 행사 투표",
+                    endAt,
+                    List.of(
+                        new VoteItemResponse(1L, "2021-12-25 12:00", 0L),
+                        new VoteItemResponse(2L, "2021-12-26 12:00", 0L),
+                        new VoteItemResponse(3L, "2021-12-27 12:00", 0L)
+                    )
+                )
+            );
+
+        mockMvc.perform(post("/api/v1/votes/dates/{teamId}", 1L)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+        )
+            .andExpect(status().isOk())
+            .andDo(document("vote-date-create",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                    fieldWithPath("title").description("투표 제목"),
+                    fieldWithPath("endAt").description("투표 종료 시간"),
+                    fieldWithPath("choices").description("투표 선택지 목록"),
+                    fieldWithPath("choices[].choice").description("시간")
+                ),
+                pathParameters(
+                    parameterWithName("teamId").description("팀 ID")
+                ),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER)
+                        .description("코드"),
+                    fieldWithPath("status").type(JsonFieldType.STRING)
+                        .description("상태"),
+                    fieldWithPath("message").type(JsonFieldType.STRING)
+                        .description("메시지"),
+                    fieldWithPath("data").type(JsonFieldType.OBJECT)
+                        .description("응답 데이터"),
+                    fieldWithPath("data.voteId").type(JsonFieldType.NUMBER)
+                        .description("투표 ID"),
+                    fieldWithPath("data.title").type(JsonFieldType.STRING)
+                        .description("투표 제목"),
+                    fieldWithPath("data.endAt").type(JsonFieldType.ARRAY)
+                        .description("투표 종료 시간"),
+                    fieldWithPath("data.choices").type(JsonFieldType.ARRAY)
+                        .description("투표 선택지 목록"),
+                    fieldWithPath("data.choices[].voteItemId").type(JsonFieldType.NUMBER)
+                        .description("투표 선택지 ID"),
+                    fieldWithPath("data.choices[].content").type(JsonFieldType.STRING)
+                        .description("투표 선택지 내용"),
+                    fieldWithPath("data.choices[].voteCount").type(JsonFieldType.NUMBER)
+                        .description("투표 선택지 투표 수")
+                )
+            ));
+
+
     }
 
 }

--- a/src/test/java/team4/footwithme/docs/vote/VoteApiDocs.java
+++ b/src/test/java/team4/footwithme/docs/vote/VoteApiDocs.java
@@ -223,7 +223,64 @@ public class VoteApiDocs extends RestDocsSupport {
                         .description("투표 선택지 투표 수")
                 )
             ));
+    }
 
+    @DisplayName("시간 투표를 조회하는 API")
+    @Test
+    void getDateVote() throws Exception {
+        LocalDateTime endAt = LocalDateTime.now().plusDays(5);
+
+        long voteId = 1L;
+
+        given(voteService.getDateVote(voteId))
+            .willReturn(
+                new VoteResponse(
+                    1L,
+                    "연말 행사 투표",
+                    endAt,
+                    List.of(
+                        new VoteItemResponse(1L, "2021-12-25 12:00", 0L),
+                        new VoteItemResponse(2L, "2021-12-26 12:00", 0L),
+                        new VoteItemResponse(3L, "2021-12-27 12:00", 0L)
+                    )
+                )
+            );
+
+        mockMvc.perform(get("/api/v1/votes/dates/{voteId}", voteId)
+                .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andDo(document("vote-date-create",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                    parameterWithName("voteId").description("투표 ID")
+                ),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER)
+                        .description("코드"),
+                    fieldWithPath("status").type(JsonFieldType.STRING)
+                        .description("상태"),
+                    fieldWithPath("message").type(JsonFieldType.STRING)
+                        .description("메시지"),
+                    fieldWithPath("data").type(JsonFieldType.OBJECT)
+                        .description("응답 데이터"),
+                    fieldWithPath("data.voteId").type(JsonFieldType.NUMBER)
+                        .description("투표 ID"),
+                    fieldWithPath("data.title").type(JsonFieldType.STRING)
+                        .description("투표 제목"),
+                    fieldWithPath("data.endAt").type(JsonFieldType.ARRAY)
+                        .description("투표 종료 시간"),
+                    fieldWithPath("data.choices").type(JsonFieldType.ARRAY)
+                        .description("투표 선택지 목록"),
+                    fieldWithPath("data.choices[].voteItemId").type(JsonFieldType.NUMBER)
+                        .description("투표 선택지 ID"),
+                    fieldWithPath("data.choices[].content").type(JsonFieldType.STRING)
+                        .description("투표 선택지 내용"),
+                    fieldWithPath("data.choices[].voteCount").type(JsonFieldType.NUMBER)
+                        .description("투표 선택지 투표 수")
+                )
+            ));
 
     }
 

--- a/src/test/java/team4/footwithme/docs/vote/VoteApiDocs.java
+++ b/src/test/java/team4/footwithme/docs/vote/VoteApiDocs.java
@@ -25,8 +25,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -279,6 +278,38 @@ public class VoteApiDocs extends RestDocsSupport {
                         .description("투표 선택지 내용"),
                     fieldWithPath("data.choices[].voteCount").type(JsonFieldType.NUMBER)
                         .description("투표 선택지 투표 수")
+                )
+            ));
+
+    }
+
+    @DisplayName("투표ID를 이용해 투표를 삭제 할 수 있다.")
+    @Test
+    void deleteVote() throws Exception {
+        long voteId = 1L;
+
+        given(voteService.deleteVote(voteId))
+            .willReturn(voteId);
+
+        mockMvc.perform(delete("/api/v1/votes/{voteId}", voteId)
+                .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andDo(document("vote-date-create",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                    parameterWithName("voteId").description("투표 ID")
+                ),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER)
+                        .description("코드"),
+                    fieldWithPath("status").type(JsonFieldType.STRING)
+                        .description("상태"),
+                    fieldWithPath("message").type(JsonFieldType.STRING)
+                        .description("메시지"),
+                    fieldWithPath("data").type(JsonFieldType.NUMBER)
+                        .description("응답 데이터 삭제한 ID")
                 )
             ));
 

--- a/src/test/java/team4/footwithme/stadium/service/StadiumServiceImplTest.java
+++ b/src/test/java/team4/footwithme/stadium/service/StadiumServiceImplTest.java
@@ -7,6 +7,7 @@ import org.locationtech.jts.geom.Point;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
+import team4.footwithme.IntegrationTestSupport;
 import team4.footwithme.global.util.PositionUtil;
 import team4.footwithme.member.domain.*;
 import team4.footwithme.member.repository.MemberRepository;
@@ -22,9 +23,8 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SpringBootTest
 @Transactional
-class StadiumServiceImplTest {
+class StadiumServiceImplTest extends IntegrationTestSupport {
 
     @Autowired
     private StadiumServiceImpl stadiumService;

--- a/src/test/java/team4/footwithme/vote/repository/VoteItemRepositoryTest.java
+++ b/src/test/java/team4/footwithme/vote/repository/VoteItemRepositoryTest.java
@@ -11,6 +11,7 @@ import team4.footwithme.member.repository.MemberRepository;
 import team4.footwithme.stadium.domain.Stadium;
 import team4.footwithme.stadium.repository.StadiumRepository;
 import team4.footwithme.vote.domain.Vote;
+import team4.footwithme.vote.domain.VoteItem;
 import team4.footwithme.vote.domain.VoteItemLocate;
 
 import java.time.LocalDateTime;
@@ -60,7 +61,7 @@ class VoteItemRepositoryTest extends IntegrationTestSupport {
         List<VoteItemLocate> savedVoteItems = voteItemRepository.saveAll(voteItemLocates);
 
         //when
-        List<VoteItemLocate> findVoteItems = voteItemRepository.findByVoteVoteId(savedVote.getVoteId());
+        List<VoteItem> findVoteItems = voteItemRepository.findByVoteVoteId(savedVote.getVoteId());
 
         //then
         Assertions.assertThat(findVoteItems).hasSize(3)

--- a/src/test/java/team4/footwithme/vote/service/VoteServiceImplTest.java
+++ b/src/test/java/team4/footwithme/vote/service/VoteServiceImplTest.java
@@ -373,7 +373,7 @@ class VoteServiceImplTest extends IntegrationTestSupport {
         assertThat(deletedVote.get()).extracting(
             "voteId", "title","endAt", "memberId", "teamId","isDeleted"
         ).containsExactly(
-            savedVote.getVoteId(), "연말 경기 투표", endAt, savedMember.getMemberId(), savedTeam.getTeamId(), IsDeleted.TRUE
+            deletedId, "연말 경기 투표", endAt, deletedVote.get().getMemberId(), deletedVote.get().getTeamId(), IsDeleted.TRUE
         );
     }
 


### PR DESCRIPTION
## 📢 기능 설명 
<!-- 필요시 실행결과 스크린샷 첨부 -->


## 연결된 issue
<!-- 연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
- close #9 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?



📣 **To Reviewers**
---
<!-- 전달사항 -->

저만 테스트에서 전체테스트가 안되나요 ? embeddedredis의 문제일까요 ㅠㅠ 전 그게 깨지기는 하는데 실제 실행은 문제없이 되어서 냅두고 PR 올렸습니다.

그리고 `@SQLDelete`를 사용하니까 테스트에서 직접 flush를 해야하더라구요 이거는 제가 알아보고 전달해드리도록 하겠습니다.

투표가 일정, 장소 두가지인데 이거 잘 리팩토링하면 서비스에서 메서드 두개 안나눠도 될거같아서 잘 생각해보고 추후에 리팩토링 하겠습니다.