### PR TITLE
[Feat/#11] 투표 마감 기능 동적 스케줄링으로 구현

### DIFF
--- a/src/main/java/team4/footwithme/config/AsyncConfig.java
+++ b/src/main/java/team4/footwithme/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package team4.footwithme.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+}

--- a/src/main/java/team4/footwithme/config/SchedulingConfig.java
+++ b/src/main/java/team4/footwithme/config/SchedulingConfig.java
@@ -1,0 +1,24 @@
+package team4.footwithme.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@EnableScheduling
+@Configuration
+public class SchedulingConfig {
+
+    public static final int POOL_SIZE = 10;
+    public static final String THREAD_NAME_PREFIX = "TaskScheduler-";
+
+    @Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+        taskScheduler.setPoolSize(POOL_SIZE);
+        taskScheduler.setThreadNamePrefix(THREAD_NAME_PREFIX);
+        taskScheduler.initialize();
+        return taskScheduler;
+    }
+}

--- a/src/main/java/team4/footwithme/vote/domain/Vote.java
+++ b/src/main/java/team4/footwithme/vote/domain/Vote.java
@@ -10,7 +10,9 @@ import org.hibernate.annotations.SQLDelete;
 import org.springframework.transaction.annotation.Transactional;
 import team4.footwithme.global.domain.BaseEntity;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -97,5 +99,9 @@ public class Vote extends BaseEntity {
 
     private boolean isWriter(Long memberId) {
         return this.memberId.equals(memberId);
+    }
+
+    public Instant getInstantEndAt() {
+        return endAt.atZone(ZoneId.systemDefault()).toInstant();
     }
 }

--- a/src/main/java/team4/footwithme/vote/domain/Vote.java
+++ b/src/main/java/team4/footwithme/vote/domain/Vote.java
@@ -7,11 +7,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
+import org.springframework.transaction.annotation.Transactional;
 import team4.footwithme.global.domain.BaseEntity;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+
+import static team4.footwithme.vote.domain.VoteStatus.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -36,6 +39,10 @@ public class Vote extends BaseEntity {
     @NotNull
     private LocalDateTime endAt;
 
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private VoteStatus voteStatus;
+
     @OneToMany(mappedBy = "vote")
     private List<VoteItem> voteItems = new ArrayList<>();
 
@@ -45,6 +52,7 @@ public class Vote extends BaseEntity {
         this.teamId = teamId;
         this.title = title;
         this.endAt = endAt;
+        this.voteStatus = OPENED;
     }
 
     public static Vote create(Long memberId, Long teamId, String title, LocalDateTime endAt) {
@@ -67,6 +75,14 @@ public class Vote extends BaseEntity {
         this.voteItems.add(voteItem);
     }
 
+    public void delete(Long memberId) {
+        checkWriterFrom(memberId);
+    }
+
+    public void updateVoteStatusToClose() {
+        this.voteStatus = CLOSED;
+    }
+
     public void update(String updateTitle, LocalDateTime updateEndAt, Long memberId) {
         checkWriterFrom(memberId);
         this.title = updateTitle;
@@ -81,9 +97,5 @@ public class Vote extends BaseEntity {
 
     private boolean isWriter(Long memberId) {
         return this.memberId.equals(memberId);
-    }
-
-    public void delete(Long memberId) {
-        checkWriterFrom(memberId);
     }
 }

--- a/src/main/java/team4/footwithme/vote/domain/VoteStatus.java
+++ b/src/main/java/team4/footwithme/vote/domain/VoteStatus.java
@@ -1,0 +1,5 @@
+package team4.footwithme.vote.domain;
+
+public enum VoteStatus {
+    OPENED, CLOSED
+}

--- a/src/main/java/team4/footwithme/vote/service/RegisteredVoteEvent.java
+++ b/src/main/java/team4/footwithme/vote/service/RegisteredVoteEvent.java
@@ -1,0 +1,7 @@
+package team4.footwithme.vote.service;
+
+public record RegisteredVoteEvent(
+    Long voteId
+) {
+
+}

--- a/src/main/java/team4/footwithme/vote/service/VoteEventHandler.java
+++ b/src/main/java/team4/footwithme/vote/service/VoteEventHandler.java
@@ -2,6 +2,7 @@ package team4.footwithme.vote.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import team4.footwithme.vote.domain.Vote;
@@ -15,6 +16,7 @@ public class VoteEventHandler {
 
     private final VoteRepository voteRepository;
 
+    @Async
     @Transactional
     @EventListener
     public void onClosedVote(RegisteredVoteEvent event) {

--- a/src/main/java/team4/footwithme/vote/service/VoteEventHandler.java
+++ b/src/main/java/team4/footwithme/vote/service/VoteEventHandler.java
@@ -1,0 +1,25 @@
+package team4.footwithme.vote.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import team4.footwithme.vote.domain.Vote;
+import team4.footwithme.vote.repository.VoteRepository;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class VoteEventHandler {
+
+    private final VoteRepository voteRepository;
+
+    @Transactional
+    @EventListener
+    public void onClosedVote(RegisteredVoteEvent event) {
+        Optional<Vote> vote = voteRepository.findById(event.voteId());
+        vote.ifPresent(Vote::updateVoteStatusToClose);
+    }
+
+}

--- a/src/test/java/team4/footwithme/vote/domain/VoteTest.java
+++ b/src/test/java/team4/footwithme/vote/domain/VoteTest.java
@@ -74,4 +74,20 @@ class VoteTest {
             .withMessage("투표 작성자만 수정,삭제할 수 있습니다.");
     }
 
+        @DisplayName("투표 상태를 마감 상태로 변경한다.")
+        @Test
+        void updateVoteStatusToClose() {
+            //given
+            Vote vote = Vote.builder()
+                .memberId(1L)
+                .teamId(1L)
+                .title("투표 제목")
+                .endAt(LocalDateTime.now().plusDays(1))
+                .build();
+            //when
+            vote.updateVoteStatusToClose();
+            //then
+            Assertions.assertThat(vote.getVoteStatus()).isEqualTo(VoteStatus.CLOSED);
+        }
+
 }


### PR DESCRIPTION
## 📢 기능 설명 
<!-- 필요시 실행결과 스크린샷 첨부 -->
동적 스케쥴링으로 구현해서 이벤트처리까지 해서 만들었습니다.
<img width="1339" alt="스크린샷 2024-10-02 오후 3 46 10" src="https://github.com/user-attachments/assets/620e0ab5-a8c6-4fd8-90c3-11077ed1d246">

일단 잘 동작하긴 합니다. update_at과 end_at과 status를 보면 종료시간에 맞춰 잘 변경된 것을 확인 할 수 있습니다.

몇개 OPENED인건 제가 여러가지 실험하다가 문제가 발생해서 그렇습니다...

## 연결된 issue
<!-- 연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
- close #11 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?



📣 **To Reviewers**
---
<!-- 전달사항 -->
너무 복잡해서 한번끊어가려고 합니다. 테스트도 문제가 있어서 실패하는 테스트임에도 통과합니다. 실제 프로덕션 코드와 간극이 발생해 `@Disabled` 해두었습니다.

```java
@Async
@Transactional(propagation = Propagation.REQUIRES_NEW)
@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
public void onClosedVote(RegisteredVoteEvent event) {
    Optional<Vote> vote = voteRepository.findById(event.voteId());
    vote.ifPresent(Vote::updateVoteStatusToClose);
}
```

이런식으로 작성하면 제가 알기로는 이벤트를 발행하는 트랜잭션이 커밋 된 이후에 이벤트리스너가 동작하는데 이벤트 발행이 스케줄러에 넣는 것이라서 그런지 위와 같이 작성하면 트랜잭션이 정상 작동하지 않습니다.

그래서 현재 코드처럼 변경하였습니다.

```java
@Async
@Transactional
@EventListener
public void onClosedVote(RegisteredVoteEvent event) {
    Optional<Vote> vote = voteRepository.findById(event.voteId());
    vote.ifPresent(Vote::updateVoteStatusToClose);
}
```

현재 코드에서 예상되는 문제점은
예외가 발생해도 이벤트가 발행되어서 스케줄러에 매핑이 됩니다.
선행 조건 때문에 클라이언트가 의도적으로 예외를 발생시키면 스케줄러에 너무 많은 task가 담겨 서버가 정상동작하지 못할 수도 있다고 보입니다.

저도 이벤트 처리 처음해봐서 잘 모르겠습니다. 혹시 아는 정보가 있다면 리뷰를 통해 알려주세요 !

이어서 할 작업 내용은
1. 종료 조건 추가
2. 종료 조건에 따른 task 미리 실행시키기
3. findById인 것 예외처리 및 findById가 아닌 삭제된지 여부 확인하여 log남기기
4. 만일에 대비해서 시스템이 종료되면 다시 켜질 때 다시 스케줄러에 추가하기 & 상태 변경하기

혹시 이 부분에 대해 아이디어가 있거나 하시면 리뷰 달아주시면 다음 작업할 때 이어나가도록 하겠습니다.

감사합니다 😄