### PR TITLE
[feat/#54] 팀 생성 및 팀원 초대에 따른 event 처리

### DIFF
--- a/src/main/java/team4/footwithme/chat/api/ChatroomApi.java
+++ b/src/main/java/team4/footwithme/chat/api/ChatroomApi.java
@@ -28,7 +28,7 @@ public class ChatroomApi {
      */
     @DeleteMapping("/{chatroomId}")
     public ApiResponse<Long> deleteChatroom(@PathVariable("chatroomId") Long chatroomId) {
-        return ApiResponse.ok(chatroomService.deleteChatroom(chatroomId));
+        return ApiResponse.ok(chatroomService.deleteChatroomByChatroomId(chatroomId));
     }
 
     /**

--- a/src/main/java/team4/footwithme/chat/domain/Chat.java
+++ b/src/main/java/team4/footwithme/chat/domain/Chat.java
@@ -68,12 +68,12 @@ public class Chat extends BaseEntity implements Serializable {
                 .build();
     }
 
-    public static Chat createEnterChat(Chatroom chatRoom, Member member, String name){
+    public static Chat createEnterChat(Chatroom chatRoom, Member member){
         return Chat.builder()
                 .chatRoom(chatRoom)
                 .member(member)
                 .chatType(ChatType.ENTER)
-                .text(name + "님이 입장했습니다.")
+                .text(member.getName() + "님이 입장했습니다.")
                 .build();
     }
 
@@ -86,12 +86,12 @@ public class Chat extends BaseEntity implements Serializable {
                 .build();
     }
 
-    public static Chat createQuitChat(Chatroom chatRoom, Member member, String name){
+    public static Chat createQuitChat(Chatroom chatRoom, Member member){
         return Chat.builder()
                 .chatRoom(chatRoom)
                 .member(member)
                 .chatType(ChatType.QUIT)
-                .text(name + "님이 채팅방을 떠났습니다.")
+                .text(member.getName() + "님이 채팅방을 떠났습니다.")
                 .build();
     }
 

--- a/src/main/java/team4/footwithme/chat/domain/Chatroom.java
+++ b/src/main/java/team4/footwithme/chat/domain/Chatroom.java
@@ -1,12 +1,8 @@
 package team4.footwithme.chat.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
@@ -19,6 +15,8 @@ import java.io.Serializable;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @SQLDelete(sql = "UPDATE chatroom SET is_deleted = 'true' WHERE chatroom_id = ?")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn
 public class Chatroom extends BaseEntity implements Serializable {
 
     @Serial
@@ -31,15 +29,12 @@ public class Chatroom extends BaseEntity implements Serializable {
     @NotNull
     private String name;
 
-    @Builder
-    private Chatroom(String name) {
+    public Chatroom(String name) {
         this.name = name;
     }
 
     public static Chatroom create(String name) {
-        return Chatroom.builder()
-            .name(name)
-            .build();
+        return new Chatroom(name);
     }
 
     public void updateName(String name) {

--- a/src/main/java/team4/footwithme/chat/domain/ReservationChatroom.java
+++ b/src/main/java/team4/footwithme/chat/domain/ReservationChatroom.java
@@ -1,0 +1,28 @@
+package team4.footwithme.chat.domain;
+
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class ReservationChatroom extends Chatroom {
+
+    private Long reservationId;
+
+    @Builder
+    private ReservationChatroom(String name, Long reservationId) {
+        super(name);
+        this.reservationId = reservationId;
+    }
+
+    public static ReservationChatroom create(String name, Long reservationId) {
+        return ReservationChatroom.builder()
+                .name(name)
+                .reservationId(reservationId)
+                .build();
+    }
+}

--- a/src/main/java/team4/footwithme/chat/domain/TeamChatroom.java
+++ b/src/main/java/team4/footwithme/chat/domain/TeamChatroom.java
@@ -1,0 +1,28 @@
+package team4.footwithme.chat.domain;
+
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class TeamChatroom extends Chatroom {
+
+    private Long teamId;
+
+    @Builder
+    private TeamChatroom(String name, Long teamId) {
+        super(name);
+        this.teamId = teamId;
+    }
+
+    public static TeamChatroom create(String name, Long teamId) {
+        return TeamChatroom.builder()
+                .name(name)
+                .teamId(teamId)
+                .build();
+    }
+}

--- a/src/main/java/team4/footwithme/chat/repository/ChatMemberRepository.java
+++ b/src/main/java/team4/footwithme/chat/repository/ChatMemberRepository.java
@@ -1,6 +1,7 @@
 package team4.footwithme.chat.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -12,7 +13,9 @@ import team4.footwithme.member.domain.Member;
 public interface ChatMemberRepository extends JpaRepository<ChatMember, Long>, CustomChatMemberRepository {
     void deleteByMemberAndChatRoom(Member member, Chatroom chatroom);
 
-    void deleteByChatRoom(Chatroom chatroom);
+    @Modifying
+    @Query("UPDATE ChatMember cm SET cm.isDeleted = 'true' WHERE cm.chatRoom = :chatRoom")
+    void updateIsDeletedForChatRoom(@Param("chatRoom") Chatroom chatroom);
 
     // 성능상 이슈가 존재해 QueryDSL로 대체함
     @Query("select COUNT(c.ChatMemberId) > 0 from ChatMember c where c.isDeleted='false' and c.member = :member and c.chatRoom = :chatroom")

--- a/src/main/java/team4/footwithme/chat/repository/ChatroomRepository.java
+++ b/src/main/java/team4/footwithme/chat/repository/ChatroomRepository.java
@@ -1,6 +1,7 @@
 package team4.footwithme.chat.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -12,8 +13,18 @@ import java.util.Optional;
 @Repository
 public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
 
+    @Modifying
+    @Query("update Chatroom c set c.isDeleted = 'true' where c.chatroomId = :id")
+    void deleteById(@Param("id") Long chatroomId);
+
     @Query("select c from Chatroom c where c.isDeleted = 'false' and c.chatroomId = :id")
     Optional<Chatroom> findByChatroomId(@Param("id") Long chatroomId);
+
+    @Query("select c from TeamChatroom c where c.isDeleted = 'false' and c.teamId = :id")
+    Optional<Chatroom> findByTeamId(@Param("id") Long teamId);
+
+    @Query("select c from ReservationChatroom c where c.isDeleted = 'false' and c.reservationId = :id")
+    Optional<Chatroom> findByReservationId(@Param("id") Long reservationId);
 
     @Query("select c from Chatroom c where c.isDeleted = 'false'")
     List<Chatroom> findAll();

--- a/src/main/java/team4/footwithme/chat/repository/RedisChatroomRepository.java
+++ b/src/main/java/team4/footwithme/chat/repository/RedisChatroomRepository.java
@@ -32,13 +32,13 @@ public class RedisChatroomRepository implements CommandLineRunner {
     private void init() {
         // 서버 재시작 시 embeddedRedis 초기화되기 때문
         chatroomRepository.findAll().forEach(chatroom -> {
-            if (findChatroomFromRedis(chatroom.getChatroomId().toString())==null) {
+            if (findChatroomFromRedis(chatroom.getChatroomId())==null) {
                 createChatRoom(chatroom);
             }
         });
     }
 
-    public Chatroom findChatroomFromRedis(String chatroomId) {
+    public Chatroom findChatroomFromRedis(Long chatroomId) {
         return opsHashChatRoom.get(CHAT_ROOMS, chatroomId);
     }
 
@@ -49,7 +49,7 @@ public class RedisChatroomRepository implements CommandLineRunner {
         opsHashChatRoom.put(CHAT_ROOMS, chatroom.getChatroomId(), chatroom);
     }
 
-    public void deleteChatroomFromRedis(String chatroomId) {
+    public void deleteChatroomFromRedis(Long chatroomId) {
         opsHashChatRoom.delete(CHAT_ROOMS, chatroomId);
     }
 }

--- a/src/main/java/team4/footwithme/chat/service/ChatMemberService.java
+++ b/src/main/java/team4/footwithme/chat/service/ChatMemberService.java
@@ -13,25 +13,25 @@ public interface ChatMemberService {
 
     ChatMemberResponse joinChatMember(ChatMemberServiceRequest request);
 
-    String joinChatTeam(List<TeamMember> teamMembers, Long teamId);
+    void joinChatTeam(List<TeamMember> teamMembers, Long teamId);
 
-    String joinChatGame(List<Participant> gameMembers, Long reservationId);
+    void joinChatGame(List<Participant> gameMembers, Long reservationId);
 
-    String joinChatMembers(List<Member> members, Chatroom chatroom);
+    void joinChatMembers(List<Member> members, Chatroom chatroom);
 
     ChatMemberResponse leaveChatMember(ChatMemberServiceRequest request);
 
-    String leaveChatRoom(Long chatroomId);
+    void leaveChatRoom(Long chatroomId);
 
-    ChatMemberResponse joinTeamChatMember(Member member, Long teamId);
+    void joinTeamChatMember(Member member, Long teamId);
 
-    ChatMemberResponse joinReservationChatMember(Member member, Long reservationId);
+    void joinReservationChatMember(Member member, Long reservationId);
 
-    String leaveTeamChatRoom(Long teamId);
+    void leaveTeamChatRoom(Long teamId);
 
-    String leaveReservationChatRoom(Long reservationId);
+    void leaveReservationChatRoom(Long reservationId);
 
-    ChatMemberResponse leaveTeamChatMember(Member member, Long teamId);
+    void leaveTeamChatMember(Member member, Long teamId);
 
-    ChatMemberResponse leaveReservationChatMember(Member member, Long reservationId);
+    void leaveReservationChatMember(Member member, Long reservationId);
 }

--- a/src/main/java/team4/footwithme/chat/service/ChatMemberService.java
+++ b/src/main/java/team4/footwithme/chat/service/ChatMemberService.java
@@ -1,5 +1,6 @@
 package team4.footwithme.chat.service;
 
+import team4.footwithme.chat.domain.Chatroom;
 import team4.footwithme.chat.service.request.ChatMemberServiceRequest;
 import team4.footwithme.chat.service.response.ChatMemberResponse;
 import team4.footwithme.member.domain.Member;
@@ -12,13 +13,25 @@ public interface ChatMemberService {
 
     ChatMemberResponse joinChatMember(ChatMemberServiceRequest request);
 
-    String joinChatTeam(List<TeamMember> teamMembers, Long chatroomId);
+    String joinChatTeam(List<TeamMember> teamMembers, Long teamId);
 
-    String joinChatGame(List<Participant> gameMembers, Long chatroomId);
+    String joinChatGame(List<Participant> gameMembers, Long reservationId);
 
-    String joinChatMembers(List<Member> members, Long chatroomId);
+    String joinChatMembers(List<Member> members, Chatroom chatroom);
 
     ChatMemberResponse leaveChatMember(ChatMemberServiceRequest request);
 
     String leaveChatRoom(Long chatroomId);
+
+    ChatMemberResponse joinTeamChatMember(Member member, Long teamId);
+
+    ChatMemberResponse joinReservationChatMember(Member member, Long reservationId);
+
+    String leaveTeamChatRoom(Long teamId);
+
+    String leaveReservationChatRoom(Long reservationId);
+
+    ChatMemberResponse leaveTeamChatMember(Member member, Long teamId);
+
+    ChatMemberResponse leaveReservationChatMember(Member member, Long reservationId);
 }

--- a/src/main/java/team4/footwithme/chat/service/ChatMemberServiceImpl.java
+++ b/src/main/java/team4/footwithme/chat/service/ChatMemberServiceImpl.java
@@ -48,18 +48,18 @@ public class ChatMemberServiceImpl implements ChatMemberService {
 
     @Override
     @Transactional
-    public ChatMemberResponse joinTeamChatMember(Member member, Long teamId) {
+    public void joinTeamChatMember(Member member, Long teamId) {
         Chatroom chatroom = getChatroomByTeamId(teamId);
 
-        return addChatMember(member, chatroom);
+        addChatMember(member, chatroom);
     }
 
     @Override
     @Transactional
-    public ChatMemberResponse joinReservationChatMember(Member member, Long reservationId) {
+    public void joinReservationChatMember(Member member, Long reservationId) {
         Chatroom chatroom = getChatroomByReservationId(reservationId);
 
-        return addChatMember(member, chatroom);
+        addChatMember(member, chatroom);
     }
 
     private ChatMemberResponse addChatMember(Member member, Chatroom chatroom){
@@ -79,42 +79,39 @@ public class ChatMemberServiceImpl implements ChatMemberService {
      * 팀원 채팅방 초대
      *
      * @param teamMembers
-     * @return
      */
     @Override
     @Transactional
-    public String joinChatTeam(List<TeamMember> teamMembers, Long teamId) {
+    public void joinChatTeam(List<TeamMember> teamMembers, Long teamId) {
         Chatroom chatroom = getChatroomByTeamId(teamId);
         List<Member> members = teamMembers.stream().map(TeamMember::getMember).collect(Collectors.toList());
 
-        return joinChatMembers(members, chatroom);
+        joinChatMembers(members, chatroom);
     }
 
     /**
      * 게임 참여 인원 채팅방 초대
      *
      * @param gameMembers
-     * @return
      */
     @Override
     @Transactional
-    public String joinChatGame(List<Participant> gameMembers, Long reservationId) {
+    public void joinChatGame(List<Participant> gameMembers, Long reservationId) {
         Chatroom chatroom = getChatroomByReservationId(reservationId);
 
         List<Member> members = gameMembers.stream().map(Participant::getMember).collect(Collectors.toList());
 
-        return joinChatMembers(members, chatroom);
+        joinChatMembers(members, chatroom);
     }
 
     /**
      * 단체로 채팅방 초대
      *
      * @param members
-     * @return
      */
     @Override
     @Transactional
-    public String joinChatMembers(List<Member> members, Chatroom chatroom){
+    public void joinChatMembers(List<Member> members, Chatroom chatroom){
 
         List<Long> oldMembersId = chatMemberRepository.findByChatroom(chatroom)
                 .stream().map(chatMember -> chatMember.getMember().getMemberId()).collect(Collectors.toList());
@@ -135,7 +132,6 @@ public class ChatMemberServiceImpl implements ChatMemberService {
 
         redisPublisher.publish(chat);
 
-        return "Successfully joined chat";
     }
 
     /**
@@ -155,18 +151,18 @@ public class ChatMemberServiceImpl implements ChatMemberService {
 
     @Override
     @Transactional
-    public ChatMemberResponse leaveTeamChatMember(Member member, Long teamId) {
+    public void leaveTeamChatMember(Member member, Long teamId) {
         Chatroom chatroom = getChatroomByTeamId(teamId);
 
-        return removeChatMember(member, chatroom);
+        removeChatMember(member, chatroom);
     }
 
     @Override
     @Transactional
-    public ChatMemberResponse leaveReservationChatMember(Member member, Long reservationId) {
+    public void leaveReservationChatMember(Member member, Long reservationId) {
         Chatroom chatroom = getChatroomByReservationId(reservationId);
 
-        return removeChatMember(member, chatroom);
+        removeChatMember(member, chatroom);
     }
 
     private ChatMemberResponse removeChatMember(Member member, Chatroom chatroom) {
@@ -190,29 +186,26 @@ public class ChatMemberServiceImpl implements ChatMemberService {
      */
     @Override
     @Transactional
-    public String leaveChatRoom(Long chatroomId) {
+    public void leaveChatRoom(Long chatroomId) {
         Chatroom chatroom = getChatroomByChatroomId(chatroomId);
 
         chatMemberRepository.updateIsDeletedForChatRoom(chatroom);
-        return "Successfully leaving the chatroom";
     }
 
     @Override
     @Transactional
-    public String leaveTeamChatRoom(Long teamId) {
+    public void leaveTeamChatRoom(Long teamId) {
         Chatroom chatroom = getChatroomByTeamId(teamId);
 
         chatMemberRepository.updateIsDeletedForChatRoom(chatroom);
-        return "Successfully leaving the chatroom";
     }
 
     @Override
     @Transactional
-    public String leaveReservationChatRoom(Long reservationId) {
+    public void leaveReservationChatRoom(Long reservationId) {
         Chatroom chatroom = getChatroomByReservationId(reservationId);
 
         chatMemberRepository.updateIsDeletedForChatRoom(chatroom);
-        return "Successfully leaving the chatroom";
     }
 
     private void checkMemberInChatroom(Member member, Chatroom chatroom) {

--- a/src/main/java/team4/footwithme/chat/service/ChatroomService.java
+++ b/src/main/java/team4/footwithme/chat/service/ChatroomService.java
@@ -6,7 +6,15 @@ import team4.footwithme.chat.service.response.ChatroomResponse;
 public interface ChatroomService {
     ChatroomResponse createChatroom(ChatroomServiceRequest request);
 
-    Long deleteChatroom(Long chatroomId);
+    Long deleteChatroomByChatroomId(Long chatroomId);
 
     ChatroomResponse updateChatroom(Long chatroomId, ChatroomServiceRequest request);
+
+    ChatroomResponse createReservationChatroom(ChatroomServiceRequest request, Long reservationId);
+
+    ChatroomResponse createTeamChatroom(ChatroomServiceRequest request, Long teamId);
+
+    Long deleteTeamChatroom(Long teamId);
+
+    Long deleteReservationChatroom(Long reservationId);
 }

--- a/src/main/java/team4/footwithme/chat/service/event/ChatEventListener.java
+++ b/src/main/java/team4/footwithme/chat/service/event/ChatEventListener.java
@@ -1,0 +1,70 @@
+package team4.footwithme.chat.service.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import team4.footwithme.chat.service.ChatMemberService;
+import team4.footwithme.chat.service.ChatroomService;
+import team4.footwithme.chat.service.request.ChatroomServiceRequest;
+
+@Component
+@RequiredArgsConstructor
+public class ChatEventListener {
+
+    private final ChatroomService chatroomService;
+    private final ChatMemberService chatMemberService;
+
+    @EventListener
+    public void onTeamPublishedEvent(TeamPublishedEvent event) {
+        chatroomService.createTeamChatroom(new ChatroomServiceRequest(event.teamId() + " 팀 채팅방"), event.teamId());
+    }
+
+    @EventListener
+    public void onTeamMemberJoinEvent(TeamMemberJoinEvent event) {
+        chatMemberService.joinTeamChatMember(event.member(), event.teamId());
+    }
+
+    @EventListener
+    public void onTeamMemberLeaveEvent(TeamMemberLeaveEvent event) {
+        chatMemberService.leaveTeamChatMember(event.member(), event.teamId());
+    }
+
+    @EventListener
+    public void onTeamMembersJoinEvent(TeamMembersJoinEvent event) {
+        chatMemberService.joinChatTeam(event.members(), event.teamId());
+    }
+
+    @EventListener
+    public void onTeamDeletedEvent(TeamDeletedEvent event) {
+        chatMemberService.leaveTeamChatRoom(event.teamId());
+        chatroomService.deleteTeamChatroom(event.teamId());
+    }
+
+    @EventListener
+    public void onReservationPublishedEvent(ReservationPublishedEvent event) {
+        chatroomService.createReservationChatroom(new ChatroomServiceRequest(event.reservationId() + " 예약 채팅방"), event.reservationId());
+    }
+
+    @EventListener
+    public void onReservationMemberJoinEvent(ReservationMemberJoinEvent event) {
+        chatMemberService.joinReservationChatMember(event.member(), event.reservationId());
+    }
+
+    @EventListener
+    public void onReservationMemberLeaveEvent(ReservationMemberLeaveEvent event) {
+        chatMemberService.leaveReservationChatMember(event.member(), event.reservationId());
+    }
+
+    @EventListener
+    public void onReservationMembersJoinEvent(ReservationMembersJoinEvent event) {
+        chatMemberService.joinChatGame(event.members(), event.reservationId());
+    }
+
+    @EventListener
+    public void onReservationDeletedEvent(ReservationDeletedEvent event) {
+        chatMemberService.leaveReservationChatRoom(event.reservationId());
+        chatroomService.deleteReservationChatroom(event.reservationId());
+    }
+
+
+}

--- a/src/main/java/team4/footwithme/chat/service/event/ReservationDeletedEvent.java
+++ b/src/main/java/team4/footwithme/chat/service/event/ReservationDeletedEvent.java
@@ -1,0 +1,6 @@
+package team4.footwithme.chat.service.event;
+
+public record ReservationDeletedEvent(
+        Long reservationId
+) {
+}

--- a/src/main/java/team4/footwithme/chat/service/event/ReservationMemberJoinEvent.java
+++ b/src/main/java/team4/footwithme/chat/service/event/ReservationMemberJoinEvent.java
@@ -1,0 +1,9 @@
+package team4.footwithme.chat.service.event;
+
+import team4.footwithme.member.domain.Member;
+
+public record ReservationMemberJoinEvent(
+        Member member,
+        Long reservationId
+) {
+}

--- a/src/main/java/team4/footwithme/chat/service/event/ReservationMemberLeaveEvent.java
+++ b/src/main/java/team4/footwithme/chat/service/event/ReservationMemberLeaveEvent.java
@@ -1,0 +1,9 @@
+package team4.footwithme.chat.service.event;
+
+import team4.footwithme.member.domain.Member;
+
+public record ReservationMemberLeaveEvent(
+        Member member,
+        Long reservationId
+) {
+}

--- a/src/main/java/team4/footwithme/chat/service/event/ReservationMembersJoinEvent.java
+++ b/src/main/java/team4/footwithme/chat/service/event/ReservationMembersJoinEvent.java
@@ -1,0 +1,11 @@
+package team4.footwithme.chat.service.event;
+
+import team4.footwithme.resevation.domain.Participant;
+
+import java.util.List;
+
+public record ReservationMembersJoinEvent(
+        List<Participant> members,
+        Long reservationId
+) {
+}

--- a/src/main/java/team4/footwithme/chat/service/event/ReservationPublishedEvent.java
+++ b/src/main/java/team4/footwithme/chat/service/event/ReservationPublishedEvent.java
@@ -1,0 +1,7 @@
+package team4.footwithme.chat.service.event;
+
+public record ReservationPublishedEvent(
+        String name,
+        Long reservationId
+) {
+}

--- a/src/main/java/team4/footwithme/chat/service/event/TeamDeletedEvent.java
+++ b/src/main/java/team4/footwithme/chat/service/event/TeamDeletedEvent.java
@@ -1,0 +1,6 @@
+package team4.footwithme.chat.service.event;
+
+public record TeamDeletedEvent(
+        Long teamId
+) {
+}

--- a/src/main/java/team4/footwithme/chat/service/event/TeamMemberJoinEvent.java
+++ b/src/main/java/team4/footwithme/chat/service/event/TeamMemberJoinEvent.java
@@ -1,0 +1,9 @@
+package team4.footwithme.chat.service.event;
+
+import team4.footwithme.member.domain.Member;
+
+public record TeamMemberJoinEvent(
+        Member member,
+        Long teamId
+) {
+}

--- a/src/main/java/team4/footwithme/chat/service/event/TeamMemberLeaveEvent.java
+++ b/src/main/java/team4/footwithme/chat/service/event/TeamMemberLeaveEvent.java
@@ -1,0 +1,9 @@
+package team4.footwithme.chat.service.event;
+
+import team4.footwithme.member.domain.Member;
+
+public record TeamMemberLeaveEvent(
+        Member member,
+        Long teamId
+) {
+}

--- a/src/main/java/team4/footwithme/chat/service/event/TeamMembersJoinEvent.java
+++ b/src/main/java/team4/footwithme/chat/service/event/TeamMembersJoinEvent.java
@@ -1,0 +1,11 @@
+package team4.footwithme.chat.service.event;
+
+import team4.footwithme.team.domain.TeamMember;
+
+import java.util.List;
+
+public record TeamMembersJoinEvent(
+        List<TeamMember> members,
+        Long teamId
+) {
+}

--- a/src/main/java/team4/footwithme/chat/service/event/TeamPublishedEvent.java
+++ b/src/main/java/team4/footwithme/chat/service/event/TeamPublishedEvent.java
@@ -1,0 +1,7 @@
+package team4.footwithme.chat.service.event;
+
+public record TeamPublishedEvent(
+        String name,
+        Long teamId) {
+
+}

--- a/src/main/java/team4/footwithme/config/redis/RedisConfig.java
+++ b/src/main/java/team4/footwithme/config/redis/RedisConfig.java
@@ -12,10 +12,14 @@ import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 import team4.footwithme.chat.service.RedisSubscriber;
 
 @Configuration
 @EnableRedisRepositories
+@EnableTransactionManagement
 @RequiredArgsConstructor
 public class RedisConfig {
 
@@ -52,6 +56,12 @@ public class RedisConfig {
         redisTemplate.setConnectionFactory(connectionFactory);
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+        redisTemplate.setEnableTransactionSupport(true);
         return redisTemplate;
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager() {
+        return new JpaTransactionManager();
     }
 }

--- a/src/main/java/team4/footwithme/resevation/domain/Participant.java
+++ b/src/main/java/team4/footwithme/resevation/domain/Participant.java
@@ -28,26 +28,21 @@ public class Participant extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @NotNull
-    private Long chatroomId;
-
     @Enumerated(EnumType.STRING)
     @NotNull
     private ParticipantRole participantRole;
 
     @Builder
-    private Participant(Reservation reservation, Member member, Long chatroomId, ParticipantRole participantRole) {
+    private Participant(Reservation reservation, Member member, ParticipantRole participantRole) {
         this.reservation = reservation;
         this.member = member;
-        this.chatroomId = chatroomId;
         this.participantRole = participantRole;
     }
 
-    public static Participant create(Reservation reservation, Member member, Long chatroomId, ParticipantRole participantRole) {
+    public static Participant create(Reservation reservation, Member member, ParticipantRole participantRole) {
         return Participant.builder()
             .reservation(reservation)
             .member(member)
-            .chatroomId(chatroomId)
             .participantRole(participantRole)
             .build();
     }

--- a/src/main/java/team4/footwithme/team/domain/Team.java
+++ b/src/main/java/team4/footwithme/team/domain/Team.java
@@ -23,9 +23,6 @@ public class Team extends BaseEntity {
     private Long stadiumId;
 
     @NotNull
-    private Long chatRoomId;
-
-    @NotNull
     @Column(length = 50)
     private String name;
 
@@ -39,20 +36,18 @@ public class Team extends BaseEntity {
     private String location;
 
     @Builder
-    private Team(Long teamId, Long stadiumId, Long chatRoomId, String name, String description, TotalRecord totalRecord, String location) {
+    private Team(Long teamId, Long stadiumId, String name, String description, TotalRecord totalRecord, String location) {
         this.teamId = teamId;
         this.stadiumId = stadiumId;
-        this.chatRoomId = chatRoomId;
         this.name = name;
         this.description = description;
         this.totalRecord = totalRecord;
         this.location = location;
     }
 
-    public static Team create(Long stadiumId, Long chatRoomId, String name, String description, int winCount, int drawCount, int loseCount, String location) {
+    public static Team create(Long stadiumId, String name, String description, int winCount, int drawCount, int loseCount, String location) {
         return Team.builder()
             .stadiumId(stadiumId)
-            .chatRoomId(chatRoomId)
             .name(name)
             .description(description)
             .totalRecord(TotalRecord.builder().build())

--- a/src/main/java/team4/footwithme/team/repository/TeamMemberRepository.java
+++ b/src/main/java/team4/footwithme/team/repository/TeamMemberRepository.java
@@ -4,11 +4,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-import team4.footwithme.member.domain.Member;
 import team4.footwithme.team.domain.Team;
 import team4.footwithme.team.domain.TeamMember;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
@@ -17,4 +17,7 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
 
     @Query("select tm from TeamMember tm where tm.isDeleted = 'false' and tm.teamMemberId = :id")
     TeamMember findByTeamMemberId(@Param("id")Long teamMemberId);
+
+    @Query("SELECT tm FROM TeamMember tm JOIN FETCH tm.member WHERE tm.isDeleted = 'false' and tm.teamMemberId = :teamMemberId")
+    Optional<TeamMember> findTeamMemberWithMemberById(@Param("teamMemberId") Long teamMemberId);
 }

--- a/src/main/java/team4/footwithme/team/service/TeamMemberServiceImpl.java
+++ b/src/main/java/team4/footwithme/team/service/TeamMemberServiceImpl.java
@@ -1,8 +1,12 @@
 package team4.footwithme.team.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team4.footwithme.chat.service.event.TeamMemberJoinEvent;
+import team4.footwithme.chat.service.event.TeamMemberLeaveEvent;
+import team4.footwithme.chat.service.event.TeamMembersJoinEvent;
 import team4.footwithme.member.domain.Member;
 import team4.footwithme.member.repository.MemberRepository;
 import team4.footwithme.team.domain.Team;
@@ -15,6 +19,7 @@ import team4.footwithme.team.service.response.TeamResponse;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -25,6 +30,8 @@ public class TeamMemberServiceImpl implements TeamMemberService{
     private final TeamRepository teamRepository;
     private final TeamMemberRepository teamMemberRepository;
 
+    private final ApplicationEventPublisher publisher;
+
     @Override
     @Transactional
     public List<TeamResponse> addTeamMembers(Long teamId, TeamMemberServiceRequest request) {
@@ -34,6 +41,14 @@ public class TeamMemberServiceImpl implements TeamMemberService{
         //return할 DTO
         List<TeamResponse> teamMembers = new ArrayList<>();
 
+        //채팅방에 초대할 TeamMember List
+        List<TeamMember> teamMemberList = new ArrayList<>();
+
+        //기존 팀 멤버 아이디 저장
+        List<Long> oldMembersId = teamMemberRepository.findTeamMembersByTeam(team).stream()
+                .map(teamMember -> teamMember.getMember().getMemberId())
+                .collect(Collectors.toList());
+
         //member 추가
         for(String email : request.emails()){
             Member member = memberRepository.findByEmail(email).orElse(null);
@@ -42,10 +57,27 @@ public class TeamMemberServiceImpl implements TeamMemberService{
                 continue;
             }
 
+            // 기존 팀 멤버가 존재할 경우 continue
+            if(oldMembersId.contains(member.getMemberId())) {
+                continue;
+            }
+
             TeamMember teamMember =  teamMemberRepository.save(TeamMember.create(team, member, TeamMemberRole.MEMBER));
 
             teamMembers.add(TeamResponse.of(teamMember));
+
+            teamMemberList.add(teamMember);
         }
+        // 팀 멤버 채팅방 초대
+        if(teamMemberList.isEmpty()){
+            return teamMembers;
+        }
+        if(teamMemberList.size() == 1){
+            publisher.publishEvent(new TeamMemberJoinEvent(teamMemberList.get(0).getMember(), team.getTeamId()));
+        } else {
+            publisher.publishEvent(new TeamMembersJoinEvent(teamMemberList, team.getTeamId()));
+        }
+
         return teamMembers;
     }
 
@@ -68,8 +100,10 @@ public class TeamMemberServiceImpl implements TeamMemberService{
     @Transactional
     public Long deleteTeamMembers(Long teamMemberId) {
         //팀 멤버 찾기
-        TeamMember teamMember = findTeamMemberByIdOrThrowException(teamMemberId);
+        TeamMember teamMember = teamMemberRepository.findTeamMemberWithMemberById(teamMemberId).orElseThrow(()->new IllegalArgumentException("존재하지 않는 팀원입니다."));
         teamMemberRepository.delete(teamMember);
+        //팀 멤버 삭제시 해당 멤버 채팅방 퇴장 이벤트 처리
+        publisher.publishEvent(new TeamMemberLeaveEvent(teamMember.getMember(), teamMember.getTeam().getTeamId()));
         return teamMemberId;
     }
 

--- a/src/main/java/team4/footwithme/team/service/TeamServiceImpl.java
+++ b/src/main/java/team4/footwithme/team/service/TeamServiceImpl.java
@@ -1,17 +1,21 @@
 package team4.footwithme.team.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import team4.footwithme.member.domain.*;
+import team4.footwithme.chat.service.event.TeamDeletedEvent;
+import team4.footwithme.chat.service.event.TeamPublishedEvent;
 import team4.footwithme.member.repository.MemberRepository;
-import team4.footwithme.team.domain.*;
+import team4.footwithme.team.domain.Team;
+import team4.footwithme.team.domain.TeamRate;
+import team4.footwithme.team.domain.TotalRecord;
 import team4.footwithme.team.repository.TeamMemberRepository;
 import team4.footwithme.team.repository.TeamRateRepository;
-import team4.footwithme.team.service.request.TeamDefaultServiceRequest;
-import team4.footwithme.team.service.response.TeamInfoResponse;
 import team4.footwithme.team.repository.TeamRepository;
+import team4.footwithme.team.service.request.TeamDefaultServiceRequest;
 import team4.footwithme.team.service.response.TeamDefaultResponse;
+import team4.footwithme.team.service.response.TeamInfoResponse;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,6 +29,8 @@ public class TeamServiceImpl implements TeamService {
     private final TeamMemberRepository teamMemberRepository;
     private final MemberRepository memberRepository;
 
+    private final ApplicationEventPublisher publisher;
+
     @Override
     @Transactional
     public TeamDefaultResponse createTeam(TeamDefaultServiceRequest dto) {
@@ -34,7 +40,6 @@ public class TeamServiceImpl implements TeamService {
          * 채팅방 생기면 해당 id 적용
          */
         Long stadiumId = null;
-        Long chatRoomId = 100000L;
 
         //TotalRecord 초기값으로 생성
         TotalRecord totalRecord = TotalRecord.builder().build();
@@ -42,7 +47,6 @@ public class TeamServiceImpl implements TeamService {
         //dto -> entity
         Team entity = Team.create(
             stadiumId,
-            chatRoomId,
             dto.name(),
             dto.description(),
             totalRecord.getWinCount(),
@@ -51,6 +55,9 @@ public class TeamServiceImpl implements TeamService {
             dto.location()
         );
         Team createdTeam = teamRepository.save(entity);
+
+        //채팅방 생성 이벤트 실행
+        publisher.publishEvent(new TeamPublishedEvent(createdTeam.getName(), createdTeam.getTeamId()));
 
         return TeamDefaultResponse.from(createdTeam);
     }
@@ -109,6 +116,8 @@ public class TeamServiceImpl implements TeamService {
         //삭제할 팀 탐색
         Team teamEntity = findTeamByIdOrThrowException(teamId);
         teamRepository.delete(teamEntity);
+        // 채팅방 삭제 이벤트 실행
+        publisher.publishEvent(new TeamDeletedEvent(teamId));
         return teamId;
     }
 

--- a/src/main/java/team4/footwithme/team/service/response/TeamDefaultResponse.java
+++ b/src/main/java/team4/footwithme/team/service/response/TeamDefaultResponse.java
@@ -5,7 +5,6 @@ import team4.footwithme.team.domain.Team;
 public record TeamDefaultResponse(
         Long teamId,
         Long stadiumId,
-        Long chatRoomId,
         String name,
         String description,
         int winCount,
@@ -17,7 +16,6 @@ public record TeamDefaultResponse(
                 return new TeamDefaultResponse(
                         team.getTeamId(),
                         team.getStadiumId(),
-                        team.getChatRoomId(),
                         team.getName(),
                         team.getDescription(),
                         team.getTotalRecord().getWinCount(),


### PR DESCRIPTION
## 📢 기능 설명 
<!-- 필요시 실행결과 스크린샷 첨부 -->
- 팀 초대 시 채팅 ( 채팅방에도 해당 회원 초대 )
![image](https://github.com/user-attachments/assets/50eccea4-7910-44e6-aa4c-a013ecab038d)

- 팀 퇴장 시 채팅 ( 채팅방에도 해당 회원 퇴장 )
![image](https://github.com/user-attachments/assets/e8f8aeef-1b18-42b3-b8ba-838324079f0e)

- 팀 생성 시 채팅방 생성
- 팀 삭제 시 해당 채팅방 인원 퇴장 및 채팅방 삭제


## 연결된 issue
<!-- 연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
- close #54
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?



📣 **To Reviewers**
---
<!-- 전달사항 -->
채팅 관련 이벤트 구현했습니다!
채팅방 관련해서 도메인 수정 부분이 있으니 확인 부탁드려요 ( 나중에 테이블 다시 생성해야 할 수도 있습니다 )
예약에 관한 이벤트도 미리 등록 해 놨습니다 나중에 예약 관련 기능 구현 시 이벤트 publish만 잘 해주면 될 것 같습니다.
team에 관련된 부분을 제법 건드려서 나중에 충돌이 많이 날 것 같네요 무섭습니다
부족한 점 및 개선할 점 피드백 주시면 감사드리겠습니다!!
