### PR TITLE
[Feat/#64] 인증 필요한 API 테스트 코드 작성 및 RESTDocs 작성

### DIFF
--- a/src/docs/asciidoc/api/stadium/court.adoc
+++ b/src/docs/asciidoc/api/stadium/court.adoc
@@ -1,5 +1,5 @@
 [[court-get-all]]
-=== 구장 전체 목록 조회 API
+== 구장 전체 목록 조회 API
 
 ==== HTTP Request
 include::{snippets}/court-get-all/http-request.adoc[]

--- a/src/docs/asciidoc/api/stadium/courtMerchant.adoc
+++ b/src/docs/asciidoc/api/stadium/courtMerchant.adoc
@@ -1,0 +1,33 @@
+[[court-register]]
+== 구장 등록 API
+
+==== HTTP Request
+include::{snippets}/court-register/http-request.adoc[]
+include::{snippets}/court-register/request-fields.adoc[]
+
+==== HTTP Response
+include::{snippets}/court-register/http-response.adoc[]
+include::{snippets}/court-register/response-fields.adoc[]
+
+[[court-update]]
+== 구장 수정 API
+
+==== HTTP Request
+include::{snippets}/court-update/http-request.adoc[]
+include::{snippets}/court-update/path-parameters.adoc[]
+include::{snippets}/court-update/request-fields.adoc[]
+
+==== HTTP Response
+include::{snippets}/court-update/http-response.adoc[]
+include::{snippets}/court-update/response-fields.adoc[]
+
+[[court-delete]]
+== 구장 삭제 API
+
+==== HTTP Request
+include::{snippets}/court-delete/http-request.adoc[]
+include::{snippets}/court-delete/path-parameters.adoc[]
+include::{snippets}/court-delete/request-fields.adoc[]
+
+==== HTTP Response
+include::{snippets}/court-delete/http-response.adoc[]

--- a/src/docs/asciidoc/api/stadium/stadium.adoc
+++ b/src/docs/asciidoc/api/stadium/stadium.adoc
@@ -1,5 +1,5 @@
 [[stadium-get-list]]
-=== 풋살장 목록 조회 API
+== 풋살장 목록 조회 API
 
 ==== HTTP Request
 include::{snippets}/stadium-get-list/http-request.adoc[]
@@ -32,7 +32,7 @@ include::{snippets}/stadium-search-name/http-response.adoc[]
 include::{snippets}/stadium-search-name/response-fields.adoc[]
 
 [[stadium-search-address]]
-== 구장 주소로 검색 API
+== 풋살장 주소로 검색 API
 
 ==== HTTP Request
 include::{snippets}/stadium-search-address/http-request.adoc[]
@@ -43,7 +43,7 @@ include::{snippets}/stadium-search-address/http-response.adoc[]
 include::{snippets}/stadium-search-address/response-fields.adoc[]
 
 [[stadium-search-location]]
-== 위치로 구장 검색 API
+== 위치로 풋살장 검색 API
 
 ==== HTTP Request
 include::{snippets}/stadium-search-location/http-request.adoc[]

--- a/src/docs/asciidoc/api/stadium/stadiumMerchant.adoc
+++ b/src/docs/asciidoc/api/stadium/stadiumMerchant.adoc
@@ -1,0 +1,33 @@
+[[stadium-register]]
+== 풋살장 등록 API
+
+==== HTTP Request
+include::{snippets}/stadium-register/http-request.adoc[]
+include::{snippets}/stadium-register/request-fields.adoc[]
+
+==== HTTP Response
+include::{snippets}/stadium-register/http-response.adoc[]
+include::{snippets}/stadium-register/response-fields.adoc[]
+
+[[stadium-update]]
+== 풋살장 수정 API
+
+==== HTTP Request
+include::{snippets}/stadium-update/http-request.adoc[]
+include::{snippets}/stadium-update/path-parameters.adoc[]
+include::{snippets}/stadium-update/request-fields.adoc[]
+
+==== HTTP Response
+include::{snippets}/stadium-update/http-response.adoc[]
+include::{snippets}/stadium-update/response-fields.adoc[]
+
+[[stadium-delete]]
+== 풋살장 삭제 API
+
+==== HTTP Request
+include::{snippets}/stadium-delete/http-request.adoc[]
+include::{snippets}/stadium-delete/path-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/stadium-delete/http-response.adoc[]
+

--- a/src/main/java/team4/footwithme/stadium/api/CourtMerchantApi.java
+++ b/src/main/java/team4/footwithme/stadium/api/CourtMerchantApi.java
@@ -27,7 +27,7 @@ public class CourtMerchantApi {
             @Validated @RequestBody CourtRegisterRequest request,
             @AuthenticationPrincipal PrincipalDetails currentUser) {
 
-        return ApiResponse.created(courtService.registerCourt(request.toServiceRequest(), currentUser.getMember().getMemberId()));
+        return ApiResponse.created(courtService.registerCourt(request.toServiceRequest(), currentUser.getMember()));
     }
 
     //@PreAuthorize("hasRole('ROLE_MERCHANT')")
@@ -37,7 +37,7 @@ public class CourtMerchantApi {
             @Validated @RequestBody CourtUpdateRequest request,
             @AuthenticationPrincipal PrincipalDetails currentUser) {
 
-        return ApiResponse.ok(courtService.updateCourt(request.toServiceRequest(), currentUser.getMember().getMemberId(), courtId));
+        return ApiResponse.ok(courtService.updateCourt(request.toServiceRequest(), currentUser.getMember(), courtId));
     }
 
     //@PreAuthorize("hasRole('ROLE_MERCHANT')")
@@ -46,7 +46,7 @@ public class CourtMerchantApi {
             @PathVariable Long courtId,
             @Validated @RequestBody CourtDeleteRequest request,
             @AuthenticationPrincipal PrincipalDetails currentUser) {
-        courtService.deleteCourt(request.toServiceRequest(), currentUser.getMember().getMemberId(), courtId);
+        courtService.deleteCourt(request.toServiceRequest(), currentUser.getMember(), courtId);
         return ApiResponse.ok(null);
     }
 }

--- a/src/main/java/team4/footwithme/stadium/api/StadiumMerchantApi.java
+++ b/src/main/java/team4/footwithme/stadium/api/StadiumMerchantApi.java
@@ -25,7 +25,7 @@ public class StadiumMerchantApi {
     public ApiResponse<StadiumDetailResponse> registerStadium(
             @Validated @RequestBody StadiumRegisterRequest request,
             @AuthenticationPrincipal PrincipalDetails currentUser) {
-        return ApiResponse.created(stadiumService.registerStadium(request.toServiceRequest(), currentUser.getMember().getMemberId()));
+        return ApiResponse.created(stadiumService.registerStadium(request.toServiceRequest(), currentUser.getMember()));
     }
 
     //@PreAuthorize("hasRole('ROLE_MERCHANT')")
@@ -34,7 +34,7 @@ public class StadiumMerchantApi {
             @PathVariable Long stadiumId,
             @Validated @RequestBody StadiumUpdateRequest request,
             @AuthenticationPrincipal PrincipalDetails currentUser) {
-        return ApiResponse.ok(stadiumService.updateStadium(request.toServiceRequest(), currentUser.getMember().getMemberId(), stadiumId));
+        return ApiResponse.ok(stadiumService.updateStadium(request.toServiceRequest(), currentUser.getMember(), stadiumId));
     }
 
     //@PreAuthorize("hasRole('ROLE_MERCHANT')")
@@ -42,7 +42,7 @@ public class StadiumMerchantApi {
     public ApiResponse<Void> deleteStadium(
             @PathVariable Long stadiumId,
             @AuthenticationPrincipal PrincipalDetails currentUser) {
-        stadiumService.deleteStadium(currentUser.getMember().getMemberId(), stadiumId);
+        stadiumService.deleteStadium(currentUser.getMember(), stadiumId);
         return ApiResponse.ok(null);
     }
 }

--- a/src/main/java/team4/footwithme/stadium/service/CourtService.java
+++ b/src/main/java/team4/footwithme/stadium/service/CourtService.java
@@ -1,6 +1,7 @@
 package team4.footwithme.stadium.service;
 
 import org.springframework.data.domain.Slice;
+import team4.footwithme.member.domain.Member;
 import team4.footwithme.stadium.service.request.CourtDeleteServiceRequest;
 import team4.footwithme.stadium.service.request.CourtRegisterServiceRequest;
 import team4.footwithme.stadium.service.request.CourtUpdateServiceRequest;
@@ -14,9 +15,9 @@ public interface CourtService {
 
     CourtDetailResponse getCourtByCourtId(Long courtId);
 
-    CourtDetailResponse registerCourt(CourtRegisterServiceRequest request, Long memberId);
+    CourtDetailResponse registerCourt(CourtRegisterServiceRequest request, Member member);
 
-    CourtDetailResponse updateCourt(CourtUpdateServiceRequest request, Long memberId, Long courtId);
+    CourtDetailResponse updateCourt(CourtUpdateServiceRequest request, Member member, Long courtId);
 
-    void deleteCourt(CourtDeleteServiceRequest request, Long memberId, Long courtId);
+    void deleteCourt(CourtDeleteServiceRequest request, Member member, Long courtId);
 }

--- a/src/main/java/team4/footwithme/stadium/service/CourtServiceImpl.java
+++ b/src/main/java/team4/footwithme/stadium/service/CourtServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team4.footwithme.global.exception.ExceptionMessage;
 import team4.footwithme.global.repository.CustomGlobalRepository;
+import team4.footwithme.member.domain.Member;
 import team4.footwithme.member.repository.MemberRepository;
 import team4.footwithme.stadium.domain.Court;
 import team4.footwithme.stadium.domain.Stadium;
@@ -56,8 +57,8 @@ public class CourtServiceImpl implements CourtService {
 
     @Override
     @Transactional
-    public CourtDetailResponse registerCourt(CourtRegisterServiceRequest request, Long memberId) {
-        validateStadiumOwnership(request.stadiumId(), memberId).createCourt(memberId);
+    public CourtDetailResponse registerCourt(CourtRegisterServiceRequest request, Member member) {
+        validateStadiumOwnership(request.stadiumId(), member.getMemberId()).createCourt(member.getMemberId());
         Court court = Court.create(
                 (Stadium) findEntityByIdOrThrowException(stadiumRepository, request.stadiumId(), ExceptionMessage.STADIUM_NOT_FOUND),
                 request.name(),
@@ -70,19 +71,19 @@ public class CourtServiceImpl implements CourtService {
 
     @Override
     @Transactional
-    public CourtDetailResponse updateCourt(CourtUpdateServiceRequest request, Long memberId, Long courtId) {
-        validateStadiumOwnership(request.stadiumId(), memberId);
+    public CourtDetailResponse updateCourt(CourtUpdateServiceRequest request, Member member, Long courtId) {
+        validateStadiumOwnership(request.stadiumId(), member.getMemberId());
         Court court = (Court) findEntityByIdOrThrowException(courtRepository, courtId, ExceptionMessage.COURT_NOT_FOUND);
-        court.updateCourt(request.stadiumId(), memberId, request.name(), request.description(), request.price_per_hour());
+        court.updateCourt(request.stadiumId(), member.getMemberId(), request.name(), request.description(), request.price_per_hour());
         return CourtDetailResponse.from(court);
     }
 
     @Override
     @Transactional
-    public void deleteCourt(CourtDeleteServiceRequest request, Long memberId, Long courtId) {
-        validateStadiumOwnership(request.stadiumId(), memberId);
+    public void deleteCourt(CourtDeleteServiceRequest request, Member member, Long courtId) {
+        validateStadiumOwnership(request.stadiumId(), member.getMemberId());
         Court court = (Court) findEntityByIdOrThrowException(courtRepository, courtId, ExceptionMessage.COURT_NOT_FOUND);
-        court.deleteCourt(request.stadiumId(), memberId);
+        court.deleteCourt(request.stadiumId(), member.getMemberId());
         courtRepository.delete(court);
     }
 

--- a/src/main/java/team4/footwithme/stadium/service/StadiumService.java
+++ b/src/main/java/team4/footwithme/stadium/service/StadiumService.java
@@ -1,6 +1,7 @@
 package team4.footwithme.stadium.service;
 
 import org.springframework.data.domain.Slice;
+import team4.footwithme.member.domain.Member;
 import team4.footwithme.stadium.service.request.StadiumRegisterServiceRequest;
 import team4.footwithme.stadium.service.request.StadiumSearchByLocationServiceRequest;
 import team4.footwithme.stadium.service.request.StadiumUpdateServiceRequest;
@@ -18,9 +19,9 @@ public interface StadiumService {
 
     Slice<StadiumsResponse> getStadiumsWithinDistance(StadiumSearchByLocationServiceRequest request, Integer page, String sort);
 
-    StadiumDetailResponse registerStadium(StadiumRegisterServiceRequest request, Long memberId);
+    StadiumDetailResponse registerStadium(StadiumRegisterServiceRequest request, Member member);
 
-    StadiumDetailResponse updateStadium(StadiumUpdateServiceRequest request, Long memberId, Long stadiumId);
+    StadiumDetailResponse updateStadium(StadiumUpdateServiceRequest request, Member member, Long stadiumId);
 
-    void deleteStadium(Long memberId, Long stadiumId);
+    void deleteStadium(Member member, Long stadiumId);
 }

--- a/src/main/java/team4/footwithme/stadium/service/StadiumServiceImpl.java
+++ b/src/main/java/team4/footwithme/stadium/service/StadiumServiceImpl.java
@@ -69,8 +69,7 @@ public class StadiumServiceImpl implements StadiumService {
 
     @Override
     @Transactional
-    public StadiumDetailResponse registerStadium(StadiumRegisterServiceRequest request, Long memberId) {
-        Member member = (Member) findEntityByIdOrThrowException(memberRepository, memberId, ExceptionMessage.MEMBER_NOT_FOUND);
+    public StadiumDetailResponse registerStadium(StadiumRegisterServiceRequest request, Member member) {
         Stadium stadium = Stadium.create(member, request.name(), request.address(), request.phoneNumber(), request.description(),
                 request.latitude(), request.longitude());
 
@@ -80,18 +79,18 @@ public class StadiumServiceImpl implements StadiumService {
 
     @Override
     @Transactional
-    public StadiumDetailResponse updateStadium(StadiumUpdateServiceRequest request, Long memberId, Long stadiumId) {
-        Stadium stadium = validateStadiumOwnership(memberId, stadiumId);
-        stadium.updateStadium(memberId, request.name(), request.address(), request.phoneNumber(), request.description(),
+    public StadiumDetailResponse updateStadium(StadiumUpdateServiceRequest request, Member member, Long stadiumId) {
+        Stadium stadium = validateStadiumOwnership(member.getMemberId(), stadiumId);
+        stadium.updateStadium(member.getMemberId(), request.name(), request.address(), request.phoneNumber(), request.description(),
                 request.latitude(), request.longitude());
         return StadiumDetailResponse.from(stadium);
     }
 
     @Override
     @Transactional
-    public void deleteStadium(Long memberId, Long stadiumId) {
-        Stadium stadium = validateStadiumOwnership(memberId, stadiumId);
-        stadium.deleteStadium(memberId);
+    public void deleteStadium(Member member, Long stadiumId) {
+        Stadium stadium = validateStadiumOwnership(member.getMemberId(), stadiumId);
+        stadium.deleteStadium(member.getMemberId());
         List<Court> courts = courtRepository.findActiveByStadiumId(stadiumId);
         if (!courts.isEmpty()) courtRepository.deleteAll(courts);
         stadiumRepository.delete(stadium);

--- a/src/test/java/team4/footwithme/ApiTestSupport.java
+++ b/src/test/java/team4/footwithme/ApiTestSupport.java
@@ -15,6 +15,8 @@ import team4.footwithme.chat.service.ChatroomService;
 import team4.footwithme.member.jwt.JwtTokenFilter;
 import team4.footwithme.stadium.api.CourtMerchantApi;
 import team4.footwithme.stadium.api.StadiumMerchantApi;
+import team4.footwithme.stadium.service.CourtService;
+import team4.footwithme.stadium.service.StadiumService;
 import team4.footwithme.vote.api.VoteApi;
 import team4.footwithme.vote.service.VoteService;
 
@@ -44,6 +46,12 @@ public abstract class ApiTestSupport {
 
     @MockBean
     protected JwtTokenFilter jwtTokenFilter;
+
+    @MockBean
+    protected CourtService courtService;
+
+    @MockBean
+    protected StadiumService stadiumService;
 
     // MockBean 통해서 실제 빈을 대체하는 가짜 빈을 주입
     // 사용하는 서비스들은 모두 MockBean으로 주입

--- a/src/test/java/team4/footwithme/ApiTestSupport.java
+++ b/src/test/java/team4/footwithme/ApiTestSupport.java
@@ -13,11 +13,13 @@ import team4.footwithme.chat.service.ChatMemberService;
 import team4.footwithme.chat.service.ChatService;
 import team4.footwithme.chat.service.ChatroomService;
 import team4.footwithme.member.jwt.JwtTokenFilter;
+import team4.footwithme.stadium.api.CourtMerchantApi;
+import team4.footwithme.stadium.api.StadiumMerchantApi;
 import team4.footwithme.vote.api.VoteApi;
 import team4.footwithme.vote.service.VoteService;
 
 @WebMvcTest(controllers = {
-    VoteApi.class, ChatApi.class, ChatroomApi.class, ChatMemberApi.class,
+    VoteApi.class, ChatApi.class, ChatroomApi.class, ChatMemberApi.class, StadiumMerchantApi.class, CourtMerchantApi.class
 })
 @AutoConfigureMockMvc(addFilters = false)
 public abstract class ApiTestSupport {

--- a/src/test/java/team4/footwithme/docs/stadium/CourtMerchantApiDocs.java
+++ b/src/test/java/team4/footwithme/docs/stadium/CourtMerchantApiDocs.java
@@ -1,4 +1,162 @@
 package team4.footwithme.docs.stadium;
 
-public class CourtMerchantApiDocs {
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import team4.footwithme.docs.RestDocsSupport;
+import team4.footwithme.security.WithMockPrincipalDetail;
+import team4.footwithme.stadium.api.CourtMerchantApi;
+import team4.footwithme.stadium.api.request.CourtRegisterRequest;
+import team4.footwithme.stadium.api.request.CourtUpdateRequest;
+import team4.footwithme.stadium.api.request.CourtDeleteRequest;
+import team4.footwithme.stadium.service.CourtService;
+import team4.footwithme.stadium.service.request.CourtRegisterServiceRequest;
+import team4.footwithme.stadium.service.response.CourtDetailResponse;
+
+import java.math.BigDecimal;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class CourtMerchantApiDocs extends RestDocsSupport {
+
+    private final CourtService courtService = mock(CourtService.class);
+
+    @Override
+    protected Object initController() {return new CourtMerchantApi(courtService);}
+
+    @Test
+    @WithMockPrincipalDetail(email = "merchant@example.com", role = team4.footwithme.member.domain.MemberRole.MERCHANT)
+    @DisplayName("구장 등록 API")
+    void registerCourt() throws Exception {
+        CourtRegisterRequest request = new CourtRegisterRequest(
+                1L,
+                "Test Court",
+                "Test Description",
+                new BigDecimal(50000)
+        );
+        CourtDetailResponse response = new CourtDetailResponse(
+                1L,
+                1L,
+                "Test Court",
+                "Test Description",
+                new BigDecimal(50000)
+        );
+
+        given(courtService.registerCourt(any(CourtRegisterServiceRequest.class), any())).willReturn(response);
+
+        mockMvc.perform(post("/api/v1/merchant/court/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(document("court-register",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("stadiumId").type(JsonFieldType.NUMBER).description("풋살장 ID"),
+                                fieldWithPath("name").type(JsonFieldType.STRING).description("구장 이름"),
+                                fieldWithPath("description").type(JsonFieldType.STRING).optional().description("구장 설명"),
+                                fieldWithPath("price_per_hour").type(JsonFieldType.NUMBER).description("시간당 가격")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                fieldWithPath("status").type(JsonFieldType.STRING).description("응답 상태"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                fieldWithPath("data.courtId").type(JsonFieldType.NUMBER).description("구장 ID"),
+                                fieldWithPath("data.stadiumId").type(JsonFieldType.NUMBER).description("풋살장 ID"),
+                                fieldWithPath("data.name").type(JsonFieldType.STRING).description("구장 이름"),
+                                fieldWithPath("data.description").type(JsonFieldType.STRING).description("구장 설명"),
+                                fieldWithPath("data.price_per_hour").type(JsonFieldType.NUMBER).description("시간당 가격")
+                        )
+                ));
+    }
+
+    @Test
+    @WithMockPrincipalDetail(email = "merchant@example.com", role = team4.footwithme.member.domain.MemberRole.MERCHANT)
+    @DisplayName("구장 수정 API")
+    void updateCourt() throws Exception {
+        Long courtId = 1L;
+        CourtUpdateRequest request = new CourtUpdateRequest(
+                1L,
+                "Updated Court",
+                "Updated Description",
+                new BigDecimal(60000)
+        );
+        CourtDetailResponse response = new CourtDetailResponse(
+                courtId,
+                1L,
+                "Updated Court",
+                "Updated Description",
+                new BigDecimal(60000)
+        );
+
+        given(courtService.updateCourt(any(), any(), eq(courtId))).willReturn(response);
+
+        mockMvc.perform(put("/api/v1/merchant/court/{courtId}", courtId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(document("court-update",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("courtId").description("수정할 구장 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("stadiumId").type(JsonFieldType.NUMBER).description("풋살장 ID"),
+                                fieldWithPath("name").type(JsonFieldType.STRING).description("구장 이름"),
+                                fieldWithPath("description").type(JsonFieldType.STRING).optional().description("구장 설명"),
+                                fieldWithPath("price_per_hour").type(JsonFieldType.NUMBER).description("시간당 가격")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                fieldWithPath("status").type(JsonFieldType.STRING).description("응답 상태"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                fieldWithPath("data.courtId").type(JsonFieldType.NUMBER).description("구장 ID"),
+                                fieldWithPath("data.stadiumId").type(JsonFieldType.NUMBER).description("풋살장 ID"),
+                                fieldWithPath("data.name").type(JsonFieldType.STRING).description("구장 이름"),
+                                fieldWithPath("data.description").type(JsonFieldType.STRING).description("구장 설명"),
+                                fieldWithPath("data.price_per_hour").type(JsonFieldType.NUMBER).description("시간당 가격")
+                        )
+                ));
+    }
+
+    @Test
+    @WithMockPrincipalDetail(email = "merchant@example.com", role = team4.footwithme.member.domain.MemberRole.MERCHANT)
+    @DisplayName("구장 삭제 API")
+    void deleteCourt() throws Exception {
+        Long courtId = 1L;
+        CourtDeleteRequest request = new CourtDeleteRequest(1L);
+
+        mockMvc.perform(delete("/api/v1/merchant/court/{courtId}", courtId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(document("court-delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("courtId").description("삭제할 구장 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("stadiumId").type(JsonFieldType.NUMBER).description("구장의 풋살장 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                fieldWithPath("status").type(JsonFieldType.STRING).description("응답 상태"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                fieldWithPath("data").type(JsonFieldType.NULL).description("삭제된 데이터 (항상 null)")
+                        )
+                ));
+    }
 }

--- a/src/test/java/team4/footwithme/docs/stadium/StadiumMerchantApiDocs.java
+++ b/src/test/java/team4/footwithme/docs/stadium/StadiumMerchantApiDocs.java
@@ -1,4 +1,174 @@
 package team4.footwithme.docs.stadium;
 
-public class StadiumMerchantApiDocs {
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import team4.footwithme.docs.RestDocsSupport;
+import team4.footwithme.security.WithMockPrincipalDetail;
+import team4.footwithme.stadium.api.StadiumMerchantApi;
+import team4.footwithme.stadium.api.request.StadiumRegisterRequest;
+import team4.footwithme.stadium.api.request.StadiumUpdateRequest;
+import team4.footwithme.stadium.service.StadiumService;
+import team4.footwithme.stadium.service.request.StadiumRegisterServiceRequest;
+import team4.footwithme.stadium.service.response.StadiumDetailResponse;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class StadiumMerchantApiDocs extends RestDocsSupport {
+
+    private final StadiumService stadiumService = mock(StadiumService.class);
+
+    @Override
+    protected Object initController() {return new StadiumMerchantApi(stadiumService);}
+
+    @Test
+    @WithMockPrincipalDetail(email = "merchant@example.com", role = team4.footwithme.member.domain.MemberRole.MERCHANT)
+    @DisplayName("풋살장 등록 API")
+    void registerStadium() throws Exception {
+        StadiumRegisterRequest request = new StadiumRegisterRequest(
+                "Test Stadium",
+                "123 Test Address",
+                "010-1234-5678",
+                "Test Description",
+                37.5665,
+                126.9780
+        );
+        StadiumDetailResponse response = new StadiumDetailResponse(
+                1L,
+                1L,
+                "Test Stadium",
+                "123 Test Address",
+                "010-1234-5678",
+                "Test Description",
+                37.5665,
+                126.9780
+        );
+
+        given(stadiumService.registerStadium(any(StadiumRegisterServiceRequest.class), any())).willReturn(response);
+
+        mockMvc.perform(post("/api/v1/merchant/stadium/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(document("stadium-register",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("name").type(JsonFieldType.STRING).description("풋살장 이름"),
+                                fieldWithPath("address").type(JsonFieldType.STRING).description("풋살장 주소"),
+                                fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("전화번호"),
+                                fieldWithPath("description").type(JsonFieldType.STRING).optional().description("풋살장 설명"),
+                                fieldWithPath("latitude").type(JsonFieldType.NUMBER).description("위도"),
+                                fieldWithPath("longitude").type(JsonFieldType.NUMBER).description("경도")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                fieldWithPath("status").type(JsonFieldType.STRING).description("응답 상태"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                fieldWithPath("data.stadiumId").type(JsonFieldType.NUMBER).description("풋살장 ID"),
+                                fieldWithPath("data.memberId").type(JsonFieldType.NUMBER).optional().description("회원 ID"),
+                                fieldWithPath("data.name").type(JsonFieldType.STRING).description("풋살장 이름"),
+                                fieldWithPath("data.address").type(JsonFieldType.STRING).description("풋살장 주소"),
+                                fieldWithPath("data.phoneNumber").type(JsonFieldType.STRING).description("전화번호"),
+                                fieldWithPath("data.description").type(JsonFieldType.STRING).description("풋살장 설명"),
+                                fieldWithPath("data.latitude").type(JsonFieldType.NUMBER).description("위도"),
+                                fieldWithPath("data.longitude").type(JsonFieldType.NUMBER).description("경도")
+                        )
+                ));
+    }
+
+    @Test
+    @WithMockPrincipalDetail(email = "merchant@example.com", role = team4.footwithme.member.domain.MemberRole.MERCHANT)
+    @DisplayName("풋살장 수정 API")
+    void updateStadium() throws Exception {
+        Long stadiumId = 1L;
+        StadiumUpdateRequest request = new StadiumUpdateRequest(
+                "Updated Stadium",
+                "456 Updated Address",
+                "010-9876-5432",
+                "Updated Description",
+                35.1796,
+                129.0756
+        );
+        StadiumDetailResponse response = new StadiumDetailResponse(
+                stadiumId,
+                null,
+                "Updated Stadium",
+                "456 Updated Address",
+                "010-9876-5432",
+                "Updated Description",
+                35.1796,
+                129.0756
+        );
+
+        given(stadiumService.updateStadium(any(), any(), eq(stadiumId))).willReturn(response);
+
+        mockMvc.perform(put("/api/v1/merchant/stadium/{stadiumId}", stadiumId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(document("stadium-update",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("stadiumId").description("수정할 풋살장 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("name").type(JsonFieldType.STRING).description("풋살장 이름"),
+                                fieldWithPath("address").type(JsonFieldType.STRING).description("풋살장 주소"),
+                                fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("전화번호"),
+                                fieldWithPath("description").type(JsonFieldType.STRING).optional().description("풋살장 설명"),
+                                fieldWithPath("latitude").type(JsonFieldType.NUMBER).description("위도"),
+                                fieldWithPath("longitude").type(JsonFieldType.NUMBER).description("경도")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                fieldWithPath("status").type(JsonFieldType.STRING).description("응답 상태"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                fieldWithPath("data.stadiumId").type(JsonFieldType.NUMBER).description("풋살장 ID"),
+                                fieldWithPath("data.memberId").type(JsonFieldType.NUMBER).optional().description("회원 ID"),
+                                fieldWithPath("data.name").type(JsonFieldType.STRING).description("풋살장 이름"),
+                                fieldWithPath("data.address").type(JsonFieldType.STRING).description("풋살장 주소"),
+                                fieldWithPath("data.phoneNumber").type(JsonFieldType.STRING).description("전화번호"),
+                                fieldWithPath("data.description").type(JsonFieldType.STRING).description("풋살장 설명"),
+                                fieldWithPath("data.latitude").type(JsonFieldType.NUMBER).description("위도"),
+                                fieldWithPath("data.longitude").type(JsonFieldType.NUMBER).description("경도")
+                        )
+                ));
+    }
+
+    @Test
+    @WithMockPrincipalDetail(email = "merchant@example.com", role = team4.footwithme.member.domain.MemberRole.MERCHANT)
+    @DisplayName("풋살장 삭제 API")
+    void deleteStadium() throws Exception {
+        Long stadiumId = 1L;
+
+        mockMvc.perform(delete("/api/v1/merchant/stadium/{stadiumId}", stadiumId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document("stadium-delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("stadiumId").description("삭제할 풋살장 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                fieldWithPath("status").type(JsonFieldType.STRING).description("응답 상태"),
+                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                fieldWithPath("data").type(JsonFieldType.NULL).description("삭제된 데이터 (항상 null)")
+                        )
+                ));
+    }
 }

--- a/src/test/java/team4/footwithme/stadium/api/CourtApiTest.java
+++ b/src/test/java/team4/footwithme/stadium/api/CourtApiTest.java
@@ -36,15 +36,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc(addFilters = false)
 class CourtApiTest extends ApiTestSupport {
 
-    @Autowired
-    private MockMvc mockMvc;
-
-    @MockBean
-    private CourtService courtService;
-
-    @Autowired
-    private ObjectMapper objectMapper;
-
     private CourtsResponse court1;
     private CourtsResponse court2;
     private CourtDetailResponse courtDetail;

--- a/src/test/java/team4/footwithme/stadium/api/CourtMerchantApiTest.java
+++ b/src/test/java/team4/footwithme/stadium/api/CourtMerchantApiTest.java
@@ -1,21 +1,139 @@
 package team4.footwithme.stadium.api;
 
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import team4.footwithme.ApiTestSupport;
+import team4.footwithme.global.api.ApiResponse;
+import team4.footwithme.stadium.api.request.CourtRegisterRequest;
+import team4.footwithme.stadium.api.request.CourtUpdateRequest;
+import team4.footwithme.stadium.api.request.CourtDeleteRequest;
+import team4.footwithme.stadium.service.CourtService;
+import team4.footwithme.stadium.service.StadiumService;
+import team4.footwithme.stadium.service.response.CourtDetailResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import team4.footwithme.security.WithMockPrincipalDetail;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.math.BigDecimal;
 
-class CourtMerchantApiTest {
-    @Disabled
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+class CourtMerchantApiTest extends ApiTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private StadiumService stadiumService;
+
+    @MockBean
+    private CourtService courtService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @Test
-    void registerCourt() {
+    @WithMockPrincipalDetail(email = "merchant@example.com", role = team4.footwithme.member.domain.MemberRole.MERCHANT)
+    @DisplayName("코트 등록 시 Created 상태를 반환해야 한다")
+    void registerCourt_shouldReturnCreatedStatus() throws Exception {
+        CourtRegisterRequest request = new CourtRegisterRequest(
+                1L,
+                "Test Court",
+                "Test Description",
+                new BigDecimal("5000.00")
+        );
+        CourtDetailResponse response = new CourtDetailResponse(
+                1L,
+                1L,
+                "Test Court",
+                "Test Description",
+                new BigDecimal("5000.00")
+        );
+
+        Mockito.when(courtService.registerCourt(any(), eq(1L))).thenReturn(response);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/merchant/court/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("201"))
+                .andExpect(jsonPath("$.status").value("CREATED"));
     }
-    @Disabled
+
     @Test
-    void updateCourt() {
+    @WithMockPrincipalDetail(email = "merchant@example.com", role = team4.footwithme.member.domain.MemberRole.MERCHANT)
+    @DisplayName("코트 수정 시 OK 상태를 반환해야 한다")
+    void updateCourt_shouldReturnOkStatus() throws Exception {
+        CourtUpdateRequest request = new CourtUpdateRequest(
+                1L,
+                "Updated Court",
+                "Updated Description",
+                new BigDecimal("6000.00")
+        );
+        CourtDetailResponse response = new CourtDetailResponse(
+                1L,
+                1L,
+                "Updated Court",
+                "Updated Description",
+                new BigDecimal("6000.00")
+        );
+
+        Mockito.when(courtService.updateCourt(any(), eq(1L), eq(1L))).thenReturn(response);
+
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/v1/merchant/court/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk());
     }
-    @Disabled
+
     @Test
-    void deleteCourt() {
+    @WithMockPrincipalDetail(email = "merchant@example.com", role = team4.footwithme.member.domain.MemberRole.MERCHANT)
+    @DisplayName("코트 삭제 시 OK 상태를 반환해야 한다")
+    void deleteCourt_shouldReturnOkStatus() throws Exception {
+        CourtDeleteRequest request = new CourtDeleteRequest(
+                1L
+        );
+
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/merchant/court/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        Mockito.verify(courtService).deleteCourt(any(), any(), eq(1L));
+    }
+
+    @Test
+    @WithMockPrincipalDetail(email = "merchant@example.com", role = team4.footwithme.member.domain.MemberRole.MERCHANT)
+    @DisplayName("유효성 검사 실패 시 Bad Request 상태를 반환해야 한다")
+    void registerCourt_shouldReturnBadRequestStatus_whenValidationFails() throws Exception {
+        CourtRegisterRequest request = new CourtRegisterRequest(
+                null,  // stadiumId is null
+                "",  // name is blank
+                "Test Description",
+                new BigDecimal("-1000.00")  // price_per_hour is negative
+        );
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/merchant/court/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").exists());
     }
 }

--- a/src/test/java/team4/footwithme/stadium/api/CourtMerchantApiTest.java
+++ b/src/test/java/team4/footwithme/stadium/api/CourtMerchantApiTest.java
@@ -32,21 +32,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 class CourtMerchantApiTest extends ApiTestSupport {
 
-    @Autowired
-    private MockMvc mockMvc;
-
-    @MockBean
-    private StadiumService stadiumService;
-
-    @MockBean
-    private CourtService courtService;
-
-    @Autowired
-    private ObjectMapper objectMapper;
-
     @Test
     @WithMockPrincipalDetail(email = "merchant@example.com", role = team4.footwithme.member.domain.MemberRole.MERCHANT)
-    @DisplayName("코트 등록 시 Created 상태를 반환해야 한다")
+    @DisplayName("구장 등록 시 Created 상태를 반환해야 한다")
     void registerCourt_shouldReturnCreatedStatus() throws Exception {
         CourtRegisterRequest request = new CourtRegisterRequest(
                 1L,
@@ -62,7 +50,7 @@ class CourtMerchantApiTest extends ApiTestSupport {
                 new BigDecimal("5000.00")
         );
 
-        Mockito.when(courtService.registerCourt(any(), eq(1L))).thenReturn(response);
+        Mockito.when(courtService.registerCourt(any(), any())).thenReturn(response);
 
         mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/merchant/court/register")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -75,7 +63,7 @@ class CourtMerchantApiTest extends ApiTestSupport {
 
     @Test
     @WithMockPrincipalDetail(email = "merchant@example.com", role = team4.footwithme.member.domain.MemberRole.MERCHANT)
-    @DisplayName("코트 수정 시 OK 상태를 반환해야 한다")
+    @DisplayName("구장 수정 시 OK 상태를 반환해야 한다")
     void updateCourt_shouldReturnOkStatus() throws Exception {
         CourtUpdateRequest request = new CourtUpdateRequest(
                 1L,
@@ -91,7 +79,7 @@ class CourtMerchantApiTest extends ApiTestSupport {
                 new BigDecimal("6000.00")
         );
 
-        Mockito.when(courtService.updateCourt(any(), eq(1L), eq(1L))).thenReturn(response);
+        Mockito.when(courtService.updateCourt(any(), any(), eq(1L))).thenReturn(response);
 
         mockMvc.perform(MockMvcRequestBuilders.put("/api/v1/merchant/court/1")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -102,7 +90,7 @@ class CourtMerchantApiTest extends ApiTestSupport {
 
     @Test
     @WithMockPrincipalDetail(email = "merchant@example.com", role = team4.footwithme.member.domain.MemberRole.MERCHANT)
-    @DisplayName("코트 삭제 시 OK 상태를 반환해야 한다")
+    @DisplayName("구장 삭제 시 OK 상태를 반환해야 한다")
     void deleteCourt_shouldReturnOkStatus() throws Exception {
         CourtDeleteRequest request = new CourtDeleteRequest(
                 1L

--- a/src/test/java/team4/footwithme/stadium/api/StadiumApiTest.java
+++ b/src/test/java/team4/footwithme/stadium/api/StadiumApiTest.java
@@ -40,17 +40,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc(addFilters = false)
 class StadiumApiTest extends ApiTestSupport {
 
-    @Autowired
-    private MockMvc mockMvc;
-
-    @MockBean
-    private StadiumService stadiumService;
 
     @MockBean
     private JwtTokenUtil jwtTokenUtil;
 
-    @Autowired
-    private ObjectMapper objectMapper;
 
     private StadiumsResponse stadium1;
     private StadiumsResponse stadium2;

--- a/src/test/java/team4/footwithme/stadium/api/StadiumMerchantApiTest.java
+++ b/src/test/java/team4/footwithme/stadium/api/StadiumMerchantApiTest.java
@@ -1,21 +1,141 @@
 package team4.footwithme.stadium.api;
 
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import team4.footwithme.ApiTestSupport;
+import team4.footwithme.global.api.ApiResponse;
+import team4.footwithme.stadium.api.request.StadiumRegisterRequest;
+import team4.footwithme.stadium.api.request.StadiumUpdateRequest;
+import team4.footwithme.stadium.service.CourtService;
+import team4.footwithme.stadium.service.StadiumService;
+import team4.footwithme.stadium.service.response.StadiumDetailResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import team4.footwithme.security.WithMockPrincipalDetail;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-class StadiumMerchantApiTest {
-    @Disabled
+class StadiumMerchantApiTest extends ApiTestSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private StadiumService stadiumService;
+
+    @MockBean
+    private CourtService courtService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @Test
-    void registerStadium() {
+    @WithMockPrincipalDetail(email = "merchant@example.com", role = team4.footwithme.member.domain.MemberRole.MERCHANT)
+    @DisplayName("풋살장 등록 시 Created 상태를 반환해야 한다")
+    void registerStadium_shouldReturnCreatedStatus() throws Exception {
+        StadiumRegisterRequest request = new StadiumRegisterRequest(
+                "Test Stadium",
+                "123 Test Address",
+                "010-1234-5678",
+                "Test Description",
+                37.5665,
+                126.9780
+        );
+        StadiumDetailResponse response = new StadiumDetailResponse(
+                1L,
+                1L,
+                "Test Stadium",
+                "123 Test Address",
+                "010-1234-5678",
+                "Test Description",
+                37.5665,
+                126.9780
+        );
+
+        Mockito.when(stadiumService.registerStadium(any(), eq(1L))).thenReturn(response);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/merchant/stadium/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("201"))
+                .andExpect(jsonPath("$.status").value("CREATED"));
     }
-    @Disabled
+
     @Test
-    void updateStadium() {
+    @WithMockPrincipalDetail(email = "merchant@example.com", role = team4.footwithme.member.domain.MemberRole.MERCHANT)
+    @DisplayName("풋살장 수정 시 OK 상태를 반환해야 한다")
+    void updateStadium_shouldReturnOkStatus() throws Exception {
+        StadiumUpdateRequest request = new StadiumUpdateRequest(
+                "Updated Stadium",
+                "456 Updated Address",
+                "010-9876-5432",
+                "Updated Description",
+                35.1796,
+                129.0756
+        );
+        StadiumDetailResponse response = new StadiumDetailResponse(
+                1L,
+                1L,
+                "Updated Stadium",
+                "456 Updated Address",
+                "010-9876-5432",
+                "Updated Description",
+                35.1796,
+                129.0756
+        );
+
+        Mockito.when(stadiumService.updateStadium(any(), eq(1L), eq(1L))).thenReturn(response);
+
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/v1/merchant/stadium/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(MockMvcResultMatchers.status().isOk());
     }
-    @Disabled
+
     @Test
-    void deleteStadium() {
+    @WithMockPrincipalDetail(email = "merchant@example.com", role = team4.footwithme.member.domain.MemberRole.MERCHANT)
+    @DisplayName("풋살장 삭제 시 OK 상태를 반환해야 한다")
+    void deleteStadium_shouldReturnOkStatus() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/merchant/stadium/1"))
+                .andDo(print())
+                .andExpect(MockMvcResultMatchers.status().isOk());
+
+        Mockito.verify(stadiumService).deleteStadium(null, 1L);
+    }
+
+    @Test
+    @WithMockPrincipalDetail(email = "merchant@example.com", role = team4.footwithme.member.domain.MemberRole.MERCHANT)
+    @DisplayName("유효성 검사 실패 시 Bad Request 상태를 반환해야 한다")
+    void registerStadium_shouldReturnBadRequestStatus_whenValidationFails() throws Exception {
+        StadiumRegisterRequest request = new StadiumRegisterRequest(
+                "",
+                "",
+                "invalid-phone",
+                "Test Description",
+                null,
+                200.0
+        );
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/merchant/stadium/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").exists());
     }
 }

--- a/src/test/java/team4/footwithme/stadium/api/StadiumMerchantApiTest.java
+++ b/src/test/java/team4/footwithme/stadium/api/StadiumMerchantApiTest.java
@@ -1,24 +1,19 @@
 package team4.footwithme.stadium.api;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import team4.footwithme.ApiTestSupport;
-import team4.footwithme.global.api.ApiResponse;
+import team4.footwithme.security.WithMockPrincipalDetail;
 import team4.footwithme.stadium.api.request.StadiumRegisterRequest;
 import team4.footwithme.stadium.api.request.StadiumUpdateRequest;
-import team4.footwithme.stadium.service.CourtService;
-import team4.footwithme.stadium.service.StadiumService;
 import team4.footwithme.stadium.service.response.StadiumDetailResponse;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import team4.footwithme.security.WithMockPrincipalDetail;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -30,12 +25,6 @@ class StadiumMerchantApiTest extends ApiTestSupport {
 
     @Autowired
     private MockMvc mockMvc;
-
-    @MockBean
-    private StadiumService stadiumService;
-
-    @MockBean
-    private CourtService courtService;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -63,7 +52,7 @@ class StadiumMerchantApiTest extends ApiTestSupport {
                 126.9780
         );
 
-        Mockito.when(stadiumService.registerStadium(any(), eq(1L))).thenReturn(response);
+        Mockito.when(stadiumService.registerStadium(any(), any())).thenReturn(response);
 
         mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/merchant/stadium/register")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -97,7 +86,7 @@ class StadiumMerchantApiTest extends ApiTestSupport {
                 129.0756
         );
 
-        Mockito.when(stadiumService.updateStadium(any(), eq(1L), eq(1L))).thenReturn(response);
+        Mockito.when(stadiumService.updateStadium(any(), any(), eq(1L))).thenReturn(response);
 
         mockMvc.perform(MockMvcRequestBuilders.put("/api/v1/merchant/stadium/1")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -114,7 +103,7 @@ class StadiumMerchantApiTest extends ApiTestSupport {
                 .andDo(print())
                 .andExpect(MockMvcResultMatchers.status().isOk());
 
-        Mockito.verify(stadiumService).deleteStadium(null, 1L);
+        Mockito.verify(stadiumService).deleteStadium(any(), eq(1L));
     }
 
     @Test

--- a/src/test/java/team4/footwithme/stadium/service/CourtServiceImplTest.java
+++ b/src/test/java/team4/footwithme/stadium/service/CourtServiceImplTest.java
@@ -124,7 +124,7 @@ class CourtServiceImplTest extends IntegrationTestSupport {
                 price
         );
 
-        CourtDetailResponse response = courtService.registerCourt(request, testMember.getMemberId());
+        CourtDetailResponse response = courtService.registerCourt(request, testMember);
 
         assertThat(response).isNotNull();
         assertThat(response)
@@ -155,7 +155,7 @@ class CourtServiceImplTest extends IntegrationTestSupport {
                 updatedPrice
         );
 
-        CourtDetailResponse response = courtService.updateCourt(request, testMember.getMemberId(), court.getCourtId());
+        CourtDetailResponse response = courtService.updateCourt(request, testMember, court.getCourtId());
 
         assertThat(response).isNotNull();
         assertThat(response)
@@ -193,7 +193,7 @@ class CourtServiceImplTest extends IntegrationTestSupport {
                 testStadium.getStadiumId()
         );
 
-        courtService.deleteCourt(request, testMember.getMemberId(), court.getCourtId());
+        courtService.deleteCourt(request, testMember, court.getCourtId());
 
         Optional<Court> deletedCourt = courtRepository.findById(court.getCourtId());
         assertThat(deletedCourt).isEmpty();
@@ -220,7 +220,7 @@ class CourtServiceImplTest extends IntegrationTestSupport {
                 price
         );
 
-        assertThatThrownBy(() -> courtService.registerCourt(request, testMember.getMemberId()))
+        assertThatThrownBy(() -> courtService.registerCourt(request, testMember))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(ExceptionMessage.STADIUM_NOT_FOUND.getText());
     }
@@ -238,7 +238,7 @@ class CourtServiceImplTest extends IntegrationTestSupport {
 
         Long invalidCourtId = -1L;
 
-        assertThatThrownBy(() -> courtService.updateCourt(request, testMember.getMemberId(), invalidCourtId))
+        assertThatThrownBy(() -> courtService.updateCourt(request, testMember, invalidCourtId))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(ExceptionMessage.COURT_NOT_FOUND.getText());
     }
@@ -252,7 +252,7 @@ class CourtServiceImplTest extends IntegrationTestSupport {
 
         Long invalidCourtId = -1L;
 
-        assertThatThrownBy(() -> courtService.deleteCourt(request, testMember.getMemberId(), invalidCourtId))
+        assertThatThrownBy(() -> courtService.deleteCourt(request, testMember, invalidCourtId))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(ExceptionMessage.COURT_NOT_FOUND.getText());
     }
@@ -283,7 +283,7 @@ class CourtServiceImplTest extends IntegrationTestSupport {
                 price
         );
 
-        assertThatThrownBy(() -> courtService.registerCourt(request, anotherMember.getMemberId()))
+        assertThatThrownBy(() -> courtService.registerCourt(request, anotherMember))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(ExceptionMessage.STADIUM_NOT_OWNED_BY_MEMBER.getText());
     }
@@ -316,7 +316,7 @@ class CourtServiceImplTest extends IntegrationTestSupport {
                 updatedPrice
         );
 
-        assertThatThrownBy(() -> courtService.updateCourt(request, anotherMember.getMemberId(), court.getCourtId()))
+        assertThatThrownBy(() -> courtService.updateCourt(request, anotherMember, court.getCourtId()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(ExceptionMessage.STADIUM_NOT_OWNED_BY_MEMBER.getText());
     }
@@ -345,7 +345,7 @@ class CourtServiceImplTest extends IntegrationTestSupport {
                 testStadium.getStadiumId()
         );
 
-        assertThatThrownBy(() -> courtService.deleteCourt(request, anotherMember.getMemberId(), court.getCourtId()))
+        assertThatThrownBy(() -> courtService.deleteCourt(request, anotherMember, court.getCourtId()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(ExceptionMessage.STADIUM_NOT_OWNED_BY_MEMBER.getText());
     }

--- a/src/test/java/team4/footwithme/stadium/service/StadiumServiceImplTest.java
+++ b/src/test/java/team4/footwithme/stadium/service/StadiumServiceImplTest.java
@@ -167,7 +167,7 @@ class StadiumServiceImplTest extends IntegrationTestSupport {
                 37.456, 126.705
         );
 
-        StadiumDetailResponse response = stadiumService.registerStadium(request, testMember.getMemberId());
+        StadiumDetailResponse response = stadiumService.registerStadium(request, testMember);
 
         assertThat(response).isNotNull();
         assertThat(response)
@@ -189,7 +189,7 @@ class StadiumServiceImplTest extends IntegrationTestSupport {
                 38.0, 128.0
         );
 
-        StadiumDetailResponse response = stadiumService.updateStadium(request, testMember.getMemberId(), stadium.getStadiumId());
+        StadiumDetailResponse response = stadiumService.updateStadium(request, testMember, stadium.getStadiumId());
 
         assertThat(response).isNotNull();
         assertThat(response)
@@ -213,7 +213,7 @@ class StadiumServiceImplTest extends IntegrationTestSupport {
     void deleteStadium() {
         Stadium stadium = stadiumRepository.findAll().get(0);
 
-        stadiumService.deleteStadium(testMember.getMemberId(), stadium.getStadiumId());
+        stadiumService.deleteStadium(testMember, stadium.getStadiumId());
 
         Optional<Stadium> deletedStadium = stadiumRepository.findById(stadium.getStadiumId());
         assertThat(deletedStadium).isEmpty();
@@ -239,7 +239,7 @@ class StadiumServiceImplTest extends IntegrationTestSupport {
 
         Long invalidStadiumId = -1L;
 
-        assertThatThrownBy(() -> stadiumService.updateStadium(request, testMember.getMemberId(), invalidStadiumId))
+        assertThatThrownBy(() -> stadiumService.updateStadium(request, testMember, invalidStadiumId))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(ExceptionMessage.STADIUM_NOT_FOUND.getText());
     }
@@ -269,7 +269,7 @@ class StadiumServiceImplTest extends IntegrationTestSupport {
                 0.0, 0.0
         );
 
-        assertThatThrownBy(() -> stadiumService.updateStadium(request, anotherMember.getMemberId(), stadium.getStadiumId()))
+        assertThatThrownBy(() -> stadiumService.updateStadium(request, anotherMember, stadium.getStadiumId()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(ExceptionMessage.STADIUM_NOT_OWNED_BY_MEMBER.getText());
     }
@@ -279,7 +279,7 @@ class StadiumServiceImplTest extends IntegrationTestSupport {
     void deleteStadium_whenStadiumDoesNotExist() {
         Long invalidStadiumId = -1L;
 
-        assertThatThrownBy(() -> stadiumService.deleteStadium(testMember.getMemberId(), invalidStadiumId))
+        assertThatThrownBy(() -> stadiumService.deleteStadium(testMember, invalidStadiumId))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(ExceptionMessage.STADIUM_NOT_FOUND.getText());
     }
@@ -304,7 +304,7 @@ class StadiumServiceImplTest extends IntegrationTestSupport {
 
         Stadium stadium = stadiumRepository.findAll().get(0);
 
-        assertThatThrownBy(() -> stadiumService.deleteStadium(anotherMember.getMemberId(), stadium.getStadiumId()))
+        assertThatThrownBy(() -> stadiumService.deleteStadium(anotherMember, stadium.getStadiumId()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(ExceptionMessage.STADIUM_NOT_OWNED_BY_MEMBER.getText());
     }


### PR DESCRIPTION
## 📢 기능 설명 
<!-- 필요시 실행결과 스크린샷 첨부 -->
- ApiTest 작성
- MemberId 관련 리펙토링
- ApiDocs 작성
- RESTDocs 작성

![image](https://github.com/user-attachments/assets/010582c2-6da9-419d-b431-1ae60e3e708e)


## 연결된 issue
<!-- 연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
- close #64
<br>

## ✅ 체크리스트
- [ ] PR 제목 규칙 잘 지켰는가? 
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?



📣 **To Reviewers**
---
<!-- 전달사항 -->
그래도 한번 작성해 봤다고 빨리 작성한 것 같습니다. 오류 해결하는거 도와주신 민혁님 민우님 감사합니다.

항상 PR 올릴 때 마다 "아 이거 했어야 했는데" 가 생각하는 것 같아요. ApiTest에서 권한 관련 테스트 코드는 나중에 작성해 보도록 하겠습니다.

큰 변화는 Court/StadiumMerchantApiDocs, Court/StadiumApiTest, court/stadiumMerchant.adoc 부분에 있습니다.

나머지는 오류 해결한다고 member.getmemberId 수정한거랑 지난 피드백 반영 과정에서 ApiTestSupport 사용한다고 수정한 내용들이 전부입니다.