### PR TITLE
[feat/#68] 용병 관련 기능 API 구현

### DIFF
--- a/src/main/java/team4/footwithme/global/exception/ExceptionMessage.java
+++ b/src/main/java/team4/footwithme/global/exception/ExceptionMessage.java
@@ -37,6 +37,7 @@ public enum ExceptionMessage {
     PARTICIPANT_NOT_IN_MEMBER("해당 회원이 매칭 예약에 존재하지 않습니다."),
     PARTICIPANT_IN_MEMBER("해당 회원이 매칭 예약에 이미 존재합니다."),
     MERCENARY_IN_RESERVATION("해당 회원은 이미 용병 신청을 했습니다."),
+    SAME_PARTICIPANT_ROLE("참가자의 역할과 수정하려는 역할이 동일합니다."),
 
     // Mercenary
     MERCENARY_NOT_FOUND("해당 용병 게시판을 찾을 수 없습니다.")

--- a/src/main/java/team4/footwithme/global/exception/ExceptionMessage.java
+++ b/src/main/java/team4/footwithme/global/exception/ExceptionMessage.java
@@ -25,7 +25,21 @@ public enum ExceptionMessage {
     CHATROOM_NOT_FOUND("해당 채팅방을 찾을 수 없습니다."),
     MEMBER_NOT_IN_CHATROOM("채팅방에 참여한 회원이 아닙니다."),
     MEMBER_IN_CHATROOM("해당 회원이 채팅방에 존재합니다."),
-    UNAUTHORIZED_MESSAGE_EDIT("해당 메세지의 수정 권한이 없습니다.")
+    UNAUTHORIZED_MESSAGE_EDIT("해당 메세지의 수정 권한이 없습니다."),
+
+    // Team
+    MEMBER_NOT_IN_TEAM("해당 회원이 팀에 존재하지 않습니다."),
+
+    // Reservation
+    RESERVATION_NOT_FOUND("해당 매칭 예약을 찾을 수 없습니다."),
+    RESERVATION_NOT_MEMBER("해당 매칭 예약 수정 권한이 없습니다."),
+    PARTICIPANT_NOT_MEMBER("해당 매칭 예약의 참가 인원 수정 권한이 없습니다."),
+    PARTICIPANT_NOT_IN_MEMBER("해당 회원이 매칭 예약에 존재하지 않습니다."),
+    PARTICIPANT_IN_MEMBER("해당 회원이 매칭 예약에 이미 존재합니다."),
+    MERCENARY_IN_RESERVATION("해당 회원은 이미 용병 신청을 했습니다."),
+
+    // Mercenary
+    MERCENARY_NOT_FOUND("해당 용병 게시판을 찾을 수 없습니다.")
 
 
     ;

--- a/src/main/java/team4/footwithme/resevation/api/MWMercenaryApi.java
+++ b/src/main/java/team4/footwithme/resevation/api/MWMercenaryApi.java
@@ -1,0 +1,41 @@
+package team4.footwithme.resevation.api;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import team4.footwithme.global.api.ApiResponse;
+import team4.footwithme.member.jwt.PrincipalDetails;
+import team4.footwithme.resevation.api.request.MWMercenaryRequest;
+import team4.footwithme.resevation.service.MercenaryServiceImpl;
+import team4.footwithme.resevation.service.response.MWMercenaryResponse;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/mercenary")
+public class MWMercenaryApi {
+    private final MercenaryServiceImpl mercenaryService;
+
+    @PostMapping
+    public ApiResponse<MWMercenaryResponse> createMercenary(@RequestBody @Valid MWMercenaryRequest request, @AuthenticationPrincipal PrincipalDetails principalDetails){
+        return ApiResponse.created(mercenaryService.createMercenary(request.toServiceRequest(), principalDetails.getMember()));
+    }
+
+    @GetMapping("/{mercenaryId}")
+    public ApiResponse<MWMercenaryResponse> getMercenary(@PathVariable Long mercenaryId){
+        return ApiResponse.ok(mercenaryService.getMercenary(mercenaryId));
+    }
+
+    @GetMapping
+    public ApiResponse<Page<MWMercenaryResponse>> getMercenaries(@RequestParam int page, @RequestParam int size){
+        PageRequest pageRequest = PageRequest.of(page-1, size);
+        return ApiResponse.ok(mercenaryService.getMercenaries(pageRequest));
+    }
+
+    @DeleteMapping("/{mercenaryId}")
+    public ApiResponse<Long> deleteMercenary(@PathVariable Long mercenaryId, @AuthenticationPrincipal PrincipalDetails principalDetails){
+        return ApiResponse.ok(mercenaryService.deleteMercenary(mercenaryId, principalDetails.getMember()));
+    }
+}

--- a/src/main/java/team4/footwithme/resevation/api/MWParticipantApi.java
+++ b/src/main/java/team4/footwithme/resevation/api/MWParticipantApi.java
@@ -1,0 +1,56 @@
+package team4.footwithme.resevation.api;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import team4.footwithme.global.api.ApiResponse;
+import team4.footwithme.member.jwt.PrincipalDetails;
+import team4.footwithme.resevation.api.request.MWParticipantUpdateRequest;
+import team4.footwithme.resevation.service.MWParticipantServiceImpl;
+import team4.footwithme.resevation.service.response.MWParticipantResponse;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/participant")
+public class MWParticipantApi {
+    private final MWParticipantServiceImpl participantService;
+
+    @PostMapping("/mercenary/{mercenaryId}")
+    public ApiResponse<MWParticipantResponse> applyMercenary(@PathVariable Long mercenaryId, @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        return ApiResponse.created(participantService.createMercenaryParticipant(mercenaryId, principalDetails.getMember()));
+    }
+
+    @PostMapping("/reservation/join/{reservationId}")
+    public ApiResponse<MWParticipantResponse> joinReservation(@PathVariable Long reservationId, @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        return ApiResponse.created(participantService.createParticipant(reservationId, principalDetails.getMember()));
+    }
+
+    @DeleteMapping("/reservation/leave/{reservationId}")
+    public ApiResponse<Long> leaveReservation(@PathVariable Long reservationId, @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        return ApiResponse.ok(participantService.deleteParticipant(reservationId, principalDetails.getMember()));
+    }
+
+    @PutMapping
+    public ApiResponse<MWParticipantResponse> updateParticipant(@RequestBody @Valid MWParticipantUpdateRequest request, @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        return ApiResponse.ok(participantService.updateMercenaryParticipant(request.toServiceResponse(), principalDetails.getMember()));
+    }
+
+    @GetMapping("/accept/{reservationId}")
+    public ApiResponse<List<MWParticipantResponse>> getAcceptParticipants(@PathVariable Long reservationId) {
+        return ApiResponse.ok(participantService.getAcceptParticipants(reservationId));
+    }
+
+    @GetMapping("/pending/{reservationId}")
+    public ApiResponse<List<MWParticipantResponse>> getPendingParticipants(@PathVariable Long reservationId) {
+        return ApiResponse.ok(participantService.getParticipantsMercenary(reservationId));
+    }
+
+    @GetMapping("/all/{reservationId}")
+    public ApiResponse<List<MWParticipantResponse>> getAllParticipants(@PathVariable Long reservationId) {
+        return ApiResponse.ok(participantService.getParticipants(reservationId));
+    }
+
+}

--- a/src/main/java/team4/footwithme/resevation/api/request/MWMercenaryRequest.java
+++ b/src/main/java/team4/footwithme/resevation/api/request/MWMercenaryRequest.java
@@ -1,0 +1,13 @@
+package team4.footwithme.resevation.api.request;
+
+import jakarta.validation.constraints.NotNull;
+import team4.footwithme.resevation.service.request.MWMercenaryServiceRequest;
+
+public record MWMercenaryRequest(
+        @NotNull
+        Long reservationId,
+        String description) {
+    public MWMercenaryServiceRequest toServiceRequest() {
+        return new MWMercenaryServiceRequest(reservationId, description);
+    }
+}

--- a/src/main/java/team4/footwithme/resevation/api/request/MWParticipantUpdateRequest.java
+++ b/src/main/java/team4/footwithme/resevation/api/request/MWParticipantUpdateRequest.java
@@ -1,0 +1,16 @@
+package team4.footwithme.resevation.api.request;
+
+import jakarta.validation.constraints.NotNull;
+import team4.footwithme.resevation.domain.ParticipantRole;
+import team4.footwithme.resevation.service.request.MWParticipantUpdateServiceRequest;
+
+public record MWParticipantUpdateRequest(
+        @NotNull
+        Long participantId,
+        @NotNull
+        ParticipantRole role
+) {
+    public MWParticipantUpdateServiceRequest toServiceResponse() {
+        return new MWParticipantUpdateServiceRequest(participantId, role);
+    }
+}

--- a/src/main/java/team4/footwithme/resevation/domain/Mercenary.java
+++ b/src/main/java/team4/footwithme/resevation/domain/Mercenary.java
@@ -19,21 +19,21 @@ public class Mercenary extends BaseEntity {
     private Long mercenaryId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "participant_id", nullable = false)
-    private Participant participant;
+    @JoinColumn(name = "reservation_id", nullable = false)
+    private Reservation reservation;
 
     @Column(length = 200, nullable = true)
     private String description;
 
     @Builder
-    private Mercenary(Participant participant, String description) {
-        this.participant = participant;
+    private Mercenary(Reservation reservation, String description) {
+        this.reservation = reservation;
         this.description = description;
     }
 
-    public static Mercenary create(Participant participant, String description) {
+    public static Mercenary create(Reservation reservation, String description) {
         return Mercenary.builder()
-            .participant(participant)
+            .reservation(reservation)
             .description(description)
             .build();
     }

--- a/src/main/java/team4/footwithme/resevation/domain/Mercenary.java
+++ b/src/main/java/team4/footwithme/resevation/domain/Mercenary.java
@@ -10,7 +10,7 @@ import team4.footwithme.global.domain.BaseEntity;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE mercenary SET is_deleted = TRUE WHERE mercenary_id = ?")
+@SQLDelete(sql = "UPDATE mercenary SET is_deleted = 'TRUE' WHERE mercenary_id = ?")
 @Entity
 public class Mercenary extends BaseEntity {
 

--- a/src/main/java/team4/footwithme/resevation/domain/Participant.java
+++ b/src/main/java/team4/footwithme/resevation/domain/Participant.java
@@ -47,4 +47,8 @@ public class Participant extends BaseEntity {
             .build();
     }
 
+    public void updateRole(ParticipantRole participantRole) {
+        this.participantRole = participantRole;
+    }
+
 }

--- a/src/main/java/team4/footwithme/resevation/domain/Participant.java
+++ b/src/main/java/team4/footwithme/resevation/domain/Participant.java
@@ -12,7 +12,7 @@ import team4.footwithme.member.domain.Member;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE participant SET is_deleted = TRUE WHERE participant_id = ?")
+@SQLDelete(sql = "UPDATE participant SET is_deleted = 'TRUE' WHERE participant_id = ?")
 @Entity
 public class Participant extends BaseEntity {
 

--- a/src/main/java/team4/footwithme/resevation/repository/CustomMercenaryRepository.java
+++ b/src/main/java/team4/footwithme/resevation/repository/CustomMercenaryRepository.java
@@ -1,0 +1,9 @@
+package team4.footwithme.resevation.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import team4.footwithme.resevation.domain.Mercenary;
+
+public interface CustomMercenaryRepository {
+    Page<Mercenary> findAllToPage(Pageable pageable);
+}

--- a/src/main/java/team4/footwithme/resevation/repository/CustomMercenaryRepositoryImpl.java
+++ b/src/main/java/team4/footwithme/resevation/repository/CustomMercenaryRepositoryImpl.java
@@ -1,0 +1,52 @@
+package team4.footwithme.resevation.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import team4.footwithme.global.domain.IsDeleted;
+import team4.footwithme.resevation.domain.Mercenary;
+import team4.footwithme.resevation.domain.ReservationStatus;
+
+import java.util.List;
+
+import static team4.footwithme.resevation.domain.QMercenary.mercenary;
+
+@RequiredArgsConstructor
+public class CustomMercenaryRepositoryImpl implements CustomMercenaryRepository {
+    private final JPAQueryFactory queryFactory;
+
+
+    @Override
+    public Page<Mercenary> findAllToPage(Pageable pageable) {
+
+        List<Mercenary> mercenaries = getMercenaryList(pageable);
+        Long count = getCount();
+
+        return new PageImpl<>(mercenaries, pageable, count);
+    }
+
+    private Long getCount() {
+        return queryFactory
+                .select(mercenary.count())
+                .from(mercenary)
+                .where(mercenary.isDeleted.eq(IsDeleted.FALSE)
+                        .and(mercenary.reservation.reservationStatus.eq(ReservationStatus.RECRUITING))
+                )
+                .fetchOne();
+    }
+
+    private List<Mercenary> getMercenaryList(Pageable pageable) {
+        return queryFactory
+                .select(mercenary)
+                .from(mercenary)
+                .where(mercenary.isDeleted.eq(IsDeleted.FALSE)
+                        .and(mercenary.reservation.reservationStatus.eq(ReservationStatus.RECRUITING))
+                )
+                .orderBy(mercenary.createdAt.desc())
+                .offset(pageable.getOffset())   // 페이지 번호
+                .limit(pageable.getPageSize() + 1)  // 페이지 사이즈
+                .fetch();
+    }
+}

--- a/src/main/java/team4/footwithme/resevation/repository/CustomParticipantRepository.java
+++ b/src/main/java/team4/footwithme/resevation/repository/CustomParticipantRepository.java
@@ -1,0 +1,11 @@
+package team4.footwithme.resevation.repository;
+
+import team4.footwithme.resevation.domain.Participant;
+
+import java.util.List;
+
+public interface CustomParticipantRepository {
+    List<Participant> findParticipantByReservationIdAndRole(Long reservationId);
+
+    List<Participant> findParticipantMercenaryByReservationId(Long reservationId);
+}

--- a/src/main/java/team4/footwithme/resevation/repository/CustomParticipantRepositoryImpl.java
+++ b/src/main/java/team4/footwithme/resevation/repository/CustomParticipantRepositoryImpl.java
@@ -1,0 +1,37 @@
+package team4.footwithme.resevation.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import team4.footwithme.global.domain.IsDeleted;
+import team4.footwithme.resevation.domain.Participant;
+import team4.footwithme.resevation.domain.ParticipantRole;
+
+import java.util.List;
+
+import static team4.footwithme.resevation.domain.QParticipant.participant;
+
+@RequiredArgsConstructor
+public class CustomParticipantRepositoryImpl implements CustomParticipantRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public List<Participant> findParticipantByReservationIdAndRole(Long reservationId) {
+        return queryFactory
+                .select(participant)
+                .from(participant)
+                .where(participant.isDeleted.eq(IsDeleted.FALSE)
+                        .and(participant.reservation.reservationId.eq(reservationId))
+                        .and(participant.participantRole.eq(ParticipantRole.MEMBER)
+                                .or(participant.participantRole.eq(ParticipantRole.ACCEPT))))
+                .fetch();
+    }
+
+    public List<Participant> findParticipantMercenaryByReservationId(Long reservationId) {
+        return queryFactory
+                .select(participant)
+                .from(participant)
+                .where(participant.isDeleted.eq(IsDeleted.FALSE)
+                        .and(participant.reservation.reservationId.eq(reservationId))
+                        .and(participant.participantRole.eq(ParticipantRole.PENDING)))
+                .fetch();
+    }
+}

--- a/src/main/java/team4/footwithme/resevation/repository/MWParticipantRepository.java
+++ b/src/main/java/team4/footwithme/resevation/repository/MWParticipantRepository.java
@@ -1,0 +1,20 @@
+package team4.footwithme.resevation.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import team4.footwithme.resevation.domain.Participant;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MWParticipantRepository extends JpaRepository<Participant,Long> , CustomParticipantRepository{
+    @Query("select p from Participant p where p.isDeleted = 'false' and p.reservation.reservationId = :id")
+    List<Participant> findParticipantsByReservationId(@Param("id") Long reservationId);
+
+    @Query("select p from Participant p where p.isDeleted = 'false' and p.reservation.reservationId = :rid and p.member.memberId = :mid")
+    Optional<Participant> findParticipantsByReservationIdAndMemberId(@Param("rid") Long reservationId, @Param("mid") Long memberId);
+
+    @Query("select p from Participant p where p.isDeleted = 'false' and p.participantId = :id")
+    Optional<Participant> findParticipantsByParticipantId(@Param("id") Long participantId);
+}

--- a/src/main/java/team4/footwithme/resevation/repository/MWReservationRepository.java
+++ b/src/main/java/team4/footwithme/resevation/repository/MWReservationRepository.java
@@ -1,0 +1,14 @@
+package team4.footwithme.resevation.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import team4.footwithme.resevation.domain.Reservation;
+
+import java.util.Optional;
+
+public interface MWReservationRepository extends JpaRepository<Reservation, Long> {
+
+    @Query("select r from Reservation r where r.isDeleted = 'false' and r.reservationId = :id")
+    Optional<Reservation> findByReservationId(@Param("id") Long reservationId);
+}

--- a/src/main/java/team4/footwithme/resevation/repository/MercenaryRepository.java
+++ b/src/main/java/team4/footwithme/resevation/repository/MercenaryRepository.java
@@ -1,10 +1,15 @@
 package team4.footwithme.resevation.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import team4.footwithme.resevation.domain.Mercenary;
 
-@Repository
-public interface MercenaryRepository extends JpaRepository<Mercenary,Long> {
+import java.util.Optional;
 
+@Repository
+public interface MercenaryRepository extends JpaRepository<Mercenary,Long>, CustomMercenaryRepository {
+    @Query("select m from Mercenary m where m.isDeleted = 'false' and m.mercenaryId = :id")
+    Optional<Mercenary> findByMercenaryId(@Param("id") Long mercenaryId);
 }

--- a/src/main/java/team4/footwithme/resevation/service/MWParticipantServiceImpl.java
+++ b/src/main/java/team4/footwithme/resevation/service/MWParticipantServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team4.footwithme.chat.service.event.ReservationMemberJoinEvent;
+import team4.footwithme.chat.service.event.ReservationMemberLeaveEvent;
 import team4.footwithme.chat.service.event.ReservationMembersJoinEvent;
 import team4.footwithme.global.exception.ExceptionMessage;
 import team4.footwithme.member.domain.Member;
@@ -114,6 +115,10 @@ public class MWParticipantServiceImpl {
                 .orElseThrow(() -> new IllegalArgumentException(ExceptionMessage.PARTICIPANT_NOT_IN_MEMBER.getText()));
 
         participantRepository.delete(participant);
+
+        if (participant.getParticipantRole().equals(ParticipantRole.MEMBER) || participant.getParticipantRole().equals(ParticipantRole.ACCEPT)) {
+            publisher.publishEvent(new ReservationMemberLeaveEvent(member, reservationId));
+        }
 
         return member.getMemberId();
     }

--- a/src/main/java/team4/footwithme/resevation/service/MWParticipantServiceImpl.java
+++ b/src/main/java/team4/footwithme/resevation/service/MWParticipantServiceImpl.java
@@ -1,0 +1,201 @@
+package team4.footwithme.resevation.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team4.footwithme.chat.service.event.ReservationMemberJoinEvent;
+import team4.footwithme.chat.service.event.ReservationMembersJoinEvent;
+import team4.footwithme.global.exception.ExceptionMessage;
+import team4.footwithme.member.domain.Member;
+import team4.footwithme.resevation.domain.Mercenary;
+import team4.footwithme.resevation.domain.Participant;
+import team4.footwithme.resevation.domain.ParticipantRole;
+import team4.footwithme.resevation.domain.Reservation;
+import team4.footwithme.resevation.repository.MWParticipantRepository;
+import team4.footwithme.resevation.repository.MWReservationRepository;
+import team4.footwithme.resevation.repository.MercenaryRepository;
+import team4.footwithme.resevation.service.request.MWParticipantUpdateServiceResponse;
+import team4.footwithme.resevation.service.response.MWParticipantResponse;
+import team4.footwithme.team.domain.Team;
+import team4.footwithme.team.domain.TeamMember;
+import team4.footwithme.team.repository.TeamMemberRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MWParticipantServiceImpl {
+    private final MercenaryRepository mercenaryRepository;
+    private final MWReservationRepository reservationRepository;
+    private final MWParticipantRepository participantRepository;
+    private final TeamMemberRepository teamMemberRepository;
+
+    private final ApplicationEventPublisher publisher;
+
+    /**
+     * 용병 추가
+     * 해당 용병 게시판의 예약에 참가한 인원이면 추가되지 않게 예외처리
+     * role은 Pending으로
+     */
+    @Transactional
+    public MWParticipantResponse createMercenaryParticipant(Long mercenaryId, Member member){
+        Mercenary mercenary = getMercenaryByMercenaryId(mercenaryId);
+
+        checkParticipantMercenaryByReservationIdAndMemberId(mercenary.getReservation().getReservationId(), member.getMemberId());
+
+        return new MWParticipantResponse(participantRepository.save(Participant.create(mercenary.getReservation(), member, ParticipantRole.PENDING)));
+    }
+
+    /**
+     * 멤버 추가
+     * 해당 예약 팀의 팀원이면 추가 가능
+     * 채팅방에도 추가
+     */
+    @Transactional
+    public MWParticipantResponse createParticipant(Long reservationId, Member member){
+        Reservation reservation = getReservationByReservationId(reservationId);
+
+        getTeamMember(reservation.getTeam(), member);
+
+        checkParticipantByReservationIdAndMemberId(reservation.getReservationId(), member.getMemberId());
+
+        publisher.publishEvent(new ReservationMemberJoinEvent(member, reservationId));
+
+        return new MWParticipantResponse(participantRepository.save(Participant.create(reservation, member, ParticipantRole.MEMBER)));
+    }
+
+    /**
+     * 멤버 리스트 한번에 추가
+     * 투표가 끝나고 예약이 생성되면 투표 진행한 사람 추가
+     * 채팅방에도 추가해주기
+     */
+    @Transactional
+    public void createParticipants(Long reservationId, List<Member> Members){
+        Reservation reservation = getReservationByReservationId(reservationId);
+
+        List<Participant> participants = new ArrayList<>();
+        for(Member member : Members){
+            participants.add(Participant.create(reservation, member, ParticipantRole.MEMBER));
+        }
+
+        participantRepository.saveAll(participants);
+
+        publisher.publishEvent(new ReservationMembersJoinEvent(participants, reservationId));
+    }
+
+    /**
+     * 예약 삭제에 따른 예약 인원 전체 삭제
+     * 채팅방에서도 삭제는 예약(채팅방) 삭제 이벤트로 발생함
+     */
+    @Transactional
+    public void deleteParticipants(Long reservationId){
+        List<Participant> participants = participantRepository.findParticipantsByReservationId(reservationId);
+
+        participantRepository.deleteAll(participants);
+    }
+
+    /**
+     * 예약 인원 삭제
+     * 예약한 사람만 할 수 있게 (Member는 로그인 한 사람)
+     * Accept or Member인 사람은 채팅방에서도 삭제
+     * 7명 이상일 때에만 취소 가능하게 구현
+     */
+    @Transactional
+    public Long deleteParticipant(Long reservationId, Member member){
+        List<Participant> participants = participantRepository.findParticipantsByReservationId(reservationId);
+
+        if(participants.size()<7){
+            throw new IllegalArgumentException(ExceptionMessage.PARTICIPANT_NOT_MEMBER.getText());
+        }
+
+        Participant participant = participants.stream().filter(p -> p.getMember().equals(member)).findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(ExceptionMessage.PARTICIPANT_NOT_IN_MEMBER.getText()));
+
+        participantRepository.delete(participant);
+
+        return member.getMemberId();
+    }
+
+    /**
+     * 용병의 상태 변경
+     * 권한은 해당 참여 인원의 예약자만 가능
+     * Accept or ignore
+     * Accept시 예약채팅방에도 추가
+     */
+    @Transactional
+    public MWParticipantResponse updateMercenaryParticipant(MWParticipantUpdateServiceResponse response, Member member){
+        Participant participant = getParticipantByParticipantId(response.participantId());
+
+        checkReservationCreatedBy(participant.getReservation(), member);
+
+        participant.updateRole(response.role());
+
+        if(response.role() == ParticipantRole.ACCEPT){
+            publisher.publishEvent(new ReservationMemberJoinEvent(member, participant.getReservation().getReservationId()));
+        }
+
+        return new MWParticipantResponse(participantRepository.save(participant));
+    }
+
+    /**
+     * 전체 예약 참여자 조회
+     * agree, member인 참여자 조회
+     */
+    @Transactional(readOnly = true)
+    public List<MWParticipantResponse> getParticipants(Long reservationId){
+        List<Participant> participants = participantRepository.findParticipantsByReservationId(reservationId);
+
+        return participants.stream().map(MWParticipantResponse::new).toList();
+    }
+
+    /**
+     * 용병 예약 참여자 조회
+     * pending인 상태인 참여자 조회
+     */
+    @Transactional(readOnly = true)
+    public List<MWParticipantResponse> getParticipantsMercenary(Long reservationId){
+        List<Participant> participants = participantRepository.findParticipantMercenaryByReservationId(reservationId);
+
+        return participants.stream().map(MWParticipantResponse::new).toList();
+    }
+
+    private Reservation getReservationByReservationId(Long reservationId) {
+        return reservationRepository.findByReservationId(reservationId)
+                .orElseThrow(() -> new IllegalArgumentException(ExceptionMessage.RESERVATION_NOT_FOUND.getText()));
+    }
+
+    private Mercenary getMercenaryByMercenaryId(Long mercenaryId) {
+        return mercenaryRepository.findByMercenaryId(mercenaryId)
+                .orElseThrow(() -> new IllegalArgumentException(ExceptionMessage.MERCENARY_NOT_FOUND.getText()));
+    }
+
+    private Participant getParticipantByParticipantId(Long participantId) {
+        return participantRepository.findParticipantsByParticipantId(participantId)
+                .orElseThrow(()->new IllegalArgumentException(ExceptionMessage.PARTICIPANT_NOT_IN_MEMBER.getText()));
+    }
+
+    private TeamMember getTeamMember(Team team, Member member) {
+        return teamMemberRepository.findByTeamIdAndMemberId(team.getTeamId(), member.getMemberId())
+                .orElseThrow(() -> new IllegalArgumentException(ExceptionMessage.MEMBER_NOT_IN_TEAM.getText()));
+    }
+
+    private void checkReservationCreatedBy(Reservation reservation, Member member) {
+        if(!reservation.getMember().equals(member)) {
+            throw new IllegalArgumentException(ExceptionMessage.RESERVATION_NOT_MEMBER.getText());
+        }
+    }
+
+    private void checkParticipantByReservationIdAndMemberId(Long reservationId, Long memberId) {
+        if(participantRepository.findParticipantsByReservationIdAndMemberId(reservationId, memberId).isPresent()){
+            throw new IllegalArgumentException(ExceptionMessage.PARTICIPANT_IN_MEMBER.getText());
+        }
+    }
+
+    private void checkParticipantMercenaryByReservationIdAndMemberId(Long reservationId, Long memberId) {
+        if(participantRepository.findParticipantsByReservationIdAndMemberId(reservationId, memberId).isPresent()){
+            throw new IllegalArgumentException(ExceptionMessage.MERCENARY_IN_RESERVATION.getText());
+        }
+    }
+}

--- a/src/main/java/team4/footwithme/resevation/service/MercenaryServiceImpl.java
+++ b/src/main/java/team4/footwithme/resevation/service/MercenaryServiceImpl.java
@@ -72,7 +72,7 @@ public class MercenaryServiceImpl implements MercenaryService{
 
 
     private String makeDescription(String description, Reservation reservation) {
-        return reservation.getMatchDate().format(DateTimeFormatter.ofPattern("(MM'/'dd'' HH':'mm'')")) +
+        return reservation.getMatchDate().format(DateTimeFormatter.ofPattern("'('MM'/'dd HH':'mm')'")) +
                 "(" +
                 reservation.getCourt().getStadium().getName() +
                 ") " +
@@ -90,7 +90,7 @@ public class MercenaryServiceImpl implements MercenaryService{
     }
 
     private void checkReservationCreatedBy(Reservation reservation, Member member) {
-        if(!reservation.getMember().equals(member)) {
+        if(!reservation.getMember().getMemberId().equals(member.getMemberId())) {
             throw new IllegalArgumentException(ExceptionMessage.RESERVATION_NOT_MEMBER.getText());
         }
     }

--- a/src/main/java/team4/footwithme/resevation/service/MercenaryServiceImpl.java
+++ b/src/main/java/team4/footwithme/resevation/service/MercenaryServiceImpl.java
@@ -1,9 +1,97 @@
 package team4.footwithme.resevation.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team4.footwithme.global.exception.ExceptionMessage;
+import team4.footwithme.member.domain.Member;
+import team4.footwithme.resevation.domain.Mercenary;
+import team4.footwithme.resevation.domain.Reservation;
+import team4.footwithme.resevation.repository.MWReservationRepository;
+import team4.footwithme.resevation.repository.MercenaryRepository;
+import team4.footwithme.resevation.service.request.MWMercenaryServiceRequest;
+import team4.footwithme.resevation.service.response.MWMercenaryResponse;
+
+import java.time.format.DateTimeFormatter;
 
 @Service
 @RequiredArgsConstructor
 public class MercenaryServiceImpl implements MercenaryService{
+    private final MercenaryRepository mercenaryRepository;
+    private final MWReservationRepository reservationRepository;
+
+    /**
+     * 용병 게시판 생성
+     * 예약자만 생성 가능
+     */
+    @Transactional
+    public MWMercenaryResponse createMercenary(MWMercenaryServiceRequest request, Member member) {
+        Reservation reservation = getReservationByReservationId(request.reservationId());
+
+        checkReservationCreatedBy(reservation, member);
+
+        return new MWMercenaryResponse(mercenaryRepository.save(Mercenary.create(reservation, makeDescription(request.description(), reservation))));
+    }
+
+    /**
+     * 단일 용병 게시판 조회
+     */
+    @Transactional(readOnly = true)
+    public MWMercenaryResponse getMercenary(Long mercenaryId) {
+        Mercenary mercenary = getMercenaryByMercenaryId(mercenaryId);
+
+        return new MWMercenaryResponse(mercenary);
+    }
+
+    /**
+     * 용병 게시판 리스트 조회
+     * 해당 용병 게시판의 예약 상태가 RECRUITING 인것만 조회
+     * 리스트 및 페이징
+     */
+    @Transactional(readOnly = true)
+    public Page<MWMercenaryResponse> getMercenaries(Pageable pageable) {
+        Page<Mercenary> mercenaries = mercenaryRepository.findAllToPage(pageable);
+        return mercenaries.map(MWMercenaryResponse::new);
+    }
+
+    /**
+     * 용병 게시판 삭제
+     * 팀장만 삭제 가능
+     */
+    @Transactional
+    public Long deleteMercenary(Long mercenaryId, Member member) {
+        Mercenary mercenary = getMercenaryByMercenaryId(mercenaryId);
+
+        checkReservationCreatedBy(mercenary.getReservation(), member);
+
+        mercenaryRepository.delete(mercenary);
+        return mercenary.getMercenaryId();
+    }
+
+
+    private String makeDescription(String description, Reservation reservation) {
+        return reservation.getMatchDate().format(DateTimeFormatter.ofPattern("(MM'/'dd'' HH':'mm'')")) +
+                "(" +
+                reservation.getCourt().getStadium().getName() +
+                ") " +
+                description;
+    }
+
+    private Reservation getReservationByReservationId(Long reservationId) {
+        return reservationRepository.findByReservationId(reservationId)
+                .orElseThrow(() -> new IllegalArgumentException(ExceptionMessage.RESERVATION_NOT_FOUND.getText()));
+    }
+
+    private Mercenary getMercenaryByMercenaryId(Long mercenaryId) {
+        return mercenaryRepository.findByMercenaryId(mercenaryId)
+                .orElseThrow(() -> new IllegalArgumentException(ExceptionMessage.MERCENARY_NOT_FOUND.getText()));
+    }
+
+    private void checkReservationCreatedBy(Reservation reservation, Member member) {
+        if(!reservation.getMember().equals(member)) {
+            throw new IllegalArgumentException(ExceptionMessage.RESERVATION_NOT_MEMBER.getText());
+        }
+    }
 }

--- a/src/main/java/team4/footwithme/resevation/service/request/MWMercenaryServiceRequest.java
+++ b/src/main/java/team4/footwithme/resevation/service/request/MWMercenaryServiceRequest.java
@@ -1,0 +1,7 @@
+package team4.footwithme.resevation.service.request;
+
+public record MWMercenaryServiceRequest(
+        Long reservationId,
+        String description
+) {
+}

--- a/src/main/java/team4/footwithme/resevation/service/request/MWParticipantUpdateServiceRequest.java
+++ b/src/main/java/team4/footwithme/resevation/service/request/MWParticipantUpdateServiceRequest.java
@@ -2,7 +2,7 @@ package team4.footwithme.resevation.service.request;
 
 import team4.footwithme.resevation.domain.ParticipantRole;
 
-public record MWParticipantUpdateServiceResponse(
+public record MWParticipantUpdateServiceRequest(
         Long participantId,
         ParticipantRole role
 ) {

--- a/src/main/java/team4/footwithme/resevation/service/request/MWParticipantUpdateServiceResponse.java
+++ b/src/main/java/team4/footwithme/resevation/service/request/MWParticipantUpdateServiceResponse.java
@@ -1,0 +1,9 @@
+package team4.footwithme.resevation.service.request;
+
+import team4.footwithme.resevation.domain.ParticipantRole;
+
+public record MWParticipantUpdateServiceResponse(
+        Long participantId,
+        ParticipantRole role
+) {
+}

--- a/src/main/java/team4/footwithme/resevation/service/response/MWMercenaryResponse.java
+++ b/src/main/java/team4/footwithme/resevation/service/response/MWMercenaryResponse.java
@@ -1,0 +1,16 @@
+package team4.footwithme.resevation.service.response;
+
+import team4.footwithme.resevation.domain.Mercenary;
+
+public record MWMercenaryResponse(
+        Long mercenaryId,
+        Long reservationId,
+        String description) {
+    public MWMercenaryResponse(Mercenary mercenary) {
+        this(
+                mercenary.getMercenaryId(),
+                mercenary.getReservation().getReservationId(),
+                mercenary.getDescription()
+        );
+    }
+}

--- a/src/main/java/team4/footwithme/resevation/service/response/MWParticipantMemberInfo.java
+++ b/src/main/java/team4/footwithme/resevation/service/response/MWParticipantMemberInfo.java
@@ -1,0 +1,20 @@
+package team4.footwithme.resevation.service.response;
+
+import team4.footwithme.member.domain.Member;
+import team4.footwithme.member.domain.MemberRole;
+
+public record MWParticipantMemberInfo(
+        Long memberId,
+        String email,
+        String name,
+        MemberRole memberRole) {
+
+    public MWParticipantMemberInfo(Member member) {
+        this(
+                member.getMemberId(),
+                member.getEmail(),
+                member.getName(),
+                member.getMemberRole()
+        );
+    }
+}

--- a/src/main/java/team4/footwithme/resevation/service/response/MWParticipantResponse.java
+++ b/src/main/java/team4/footwithme/resevation/service/response/MWParticipantResponse.java
@@ -1,0 +1,17 @@
+package team4.footwithme.resevation.service.response;
+
+import team4.footwithme.resevation.domain.Participant;
+
+public record MWParticipantResponse(
+        Long participantId,
+        Long reservationId,
+        MWParticipantMemberInfo memberInfo
+        ) {
+    public MWParticipantResponse(Participant participant) {
+        this(
+                participant.getParticipantId(),
+                participant.getReservation().getReservationId(),
+                new MWParticipantMemberInfo(participant.getMember())
+        );
+    }
+}

--- a/src/main/java/team4/footwithme/resevation/service/response/MWParticipantResponse.java
+++ b/src/main/java/team4/footwithme/resevation/service/response/MWParticipantResponse.java
@@ -1,16 +1,19 @@
 package team4.footwithme.resevation.service.response;
 
 import team4.footwithme.resevation.domain.Participant;
+import team4.footwithme.resevation.domain.ParticipantRole;
 
 public record MWParticipantResponse(
         Long participantId,
         Long reservationId,
+        ParticipantRole role,
         MWParticipantMemberInfo memberInfo
         ) {
     public MWParticipantResponse(Participant participant) {
         this(
                 participant.getParticipantId(),
                 participant.getReservation().getReservationId(),
+                participant.getParticipantRole(),
                 new MWParticipantMemberInfo(participant.getMember())
         );
     }


### PR DESCRIPTION
## 📢 기능 설명 
<!-- 필요시 실행결과 스크린샷 첨부 -->
### 용병 관련 기능
- 용병 모집 API (용병 게시판 생성)
- 용병 모집 취소 API (용병 게시판 삭제)
- 용병 게시판 리스트 조회 ( 페이지네이션 )
- 단일 용병 게시판 조회
### 예약 인원 관련 기능
- 용병 추가 API
- 팀원 매칭 예약 참가 API
- 매칭 예약 탈퇴 API
- 매칭 예약 인원 역할 수정 API
- 매칭 예약 참가자 조회 API

## 연결된 issue
<!-- 연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
- close #68
<br>

## ✅ 체크리스트
- [ ] PR 제목 규칙 잘 지켰는가? 
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?



📣 **To Reviewers**
---
<!-- 전달사항 -->
Postman으로 우선 테스트는 완료 했습니다!

파일은 우선 제가 개발한 기능들은 파일명 앞에 MW를 붙혔는데 용병쪽은 저만 건들 줄 알고 안붙혔습니다.

빠진 기능이나 추가되면 좋겠는 기능 말씀해주시면 최대한 더 구현 해보겠습니다.

머지하면 해당 기능들 테스트 코드 진행 하겠습니다!
