### PR TITLE
[Feat/#109] Command, Query 요청 데이터 소스 분리

### DIFF
--- a/src/main/java/team4/footwithme/config/DataSourceConfig.java
+++ b/src/main/java/team4/footwithme/config/DataSourceConfig.java
@@ -1,0 +1,60 @@
+package team4.footwithme.config;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.*;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+import team4.footwithme.config.datasource.ReplicationRoutingDataSource;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+
+@Profile("prod")
+@Configuration
+public class DataSourceConfig {
+
+    @ConfigurationProperties(prefix = "spring.datasource.command.hikari")
+    @Bean(name = "commandDataSource")
+    public DataSource commandDataSource() {
+        return DataSourceBuilder.create()
+            .type(HikariDataSource.class)
+            .build();
+    }
+
+    @ConfigurationProperties(prefix = "spring.datasource.query.hikari")
+    @Bean(name = "queryDataSource")
+    public DataSource queryDataSource() {
+        return DataSourceBuilder.create()
+            .type(HikariDataSource.class)
+            .build();
+    }
+
+    @DependsOn({"commandDataSource", "queryDataSource"})
+    @Bean
+    public DataSource routingDataSource(@Qualifier("commandDataSource") DataSource command,
+                                        @Qualifier("queryDataSource") DataSource query) {
+
+        ReplicationRoutingDataSource routingDataSource = new ReplicationRoutingDataSource();
+
+        Map<Object, Object> dataSourceMap = new HashMap<>();
+
+        dataSourceMap.put("command", command);
+        dataSourceMap.put("query", query);
+
+        routingDataSource.setTargetDataSources(dataSourceMap);
+        routingDataSource.setDefaultTargetDataSource(command);
+
+        return routingDataSource;
+    }
+
+    @DependsOn("routingDataSource")
+    @Primary
+    @Bean
+    public DataSource dataSource(DataSource routingDataSource) {
+        return new LazyConnectionDataSourceProxy(routingDataSource);
+    }
+
+}

--- a/src/main/java/team4/footwithme/config/datasource/ReplicationRoutingDataSource.java
+++ b/src/main/java/team4/footwithme/config/datasource/ReplicationRoutingDataSource.java
@@ -1,0 +1,17 @@
+package team4.footwithme.config.datasource;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+
+import static org.springframework.transaction.support.TransactionSynchronizationManager.isCurrentTransactionReadOnly;
+
+public class ReplicationRoutingDataSource extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        if (isCurrentTransactionReadOnly()) {
+            return "query";
+        }
+        return "command";
+    }
+
+}


### PR DESCRIPTION
## 📢 기능 설명 
<!-- 필요시 실행결과 스크린샷 첨부 -->
`Transactional(readOnly = true)` 가 붙은 메서드는 Datasource를 조회용 DB를 바라보게 하여서 CQRS 도입을 준비하였습니다. 

## 연결된 issue
<!-- 연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
- close #109
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?



📣 **To Reviewers**
---
<!-- 전달사항 -->
현재 방식은 읽기 전용 DB에 쓰기를 아예 할 수 없기 때문에 AOP를 이용하면 더 유연한 제어가 가능하다고 합니다.

AOP를 이용하는 방법은  일반 `Transactional` 옵션을 이용할 뿐 아니라 커스텀 어노테이션을 통해서 관리 할 수 있다고 하는데 읽기 전용 DB에 대해서 세밀한 제어가 필요하다고 생각하지 않아서 적용하지 않았습니다.

프로필을 prod에만 적용해두어서, 배포환경에서만 적용되도록 하였습니다.

DB Replication을 해야하는데 잘 안되네요.. 혹시 docker-compose 또는 my.cnf 잘 관리 할 줄 아시는 분 있으면 도움 부탁드립니다.